### PR TITLE
feat: configure Supabase Auth (phone SMS + Apple)

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -9,6 +9,9 @@ SUPABASE_ANON_KEY=op://run-jin/supabase/anon-key
 SUPABASE_SERVICE_ROLE_KEY=op://run-jin/supabase/service-role-key
 SUPABASE_DB_PASSWORD=op://run-jin/supabase/db-password
 
+# Supabase Auth (Apple Sign-In)
+SUPABASE_AUTH_APPLE_SECRET=op://run-jin/supabase/apple-auth-secret
+
 # Firebase
 FIREBASE_API_KEY=op://run-jin/firebase/api-key
 FIREBASE_PROJECT_ID=op://run-jin/firebase/project-id

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -58,8 +58,18 @@ enable_confirmations = false
 "+818000000002" = "123456"
 "+818000000003" = "123456"
 
-[auth.external.apple]
+[auth.sms.twilio]
 enabled = false
+account_sid = ""
+message_service_sid = ""
+auth_token = ""
+
+[auth.external.apple]
+enabled = true
+client_id = "app.space.k1t.run-jin"
+secret = "env(SUPABASE_AUTH_APPLE_SECRET)"
+redirect_uri = ""
+url = ""
 
 [analytics]
 enabled = false


### PR DESCRIPTION
## Summary
- SMS認証プロバイダー設定 (Twilio、ローカル開発時はdisabled)
- テスト用OTP番号設定 (+818000000001~3 → 123456)
- Apple Sign-Inをフォールバック認証として有効化
- .env.tplにApple Auth Secretを追加

Closes #5

## Test plan
- [ ] `supabase start` でAuth設定が適用されることを確認
- [ ] テスト用番号でOTPバイパス動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)