### PR TITLE
feat: Supabase client initialization and AuthService

### DIFF
--- a/run-jin/Core/Protocols/AuthServiceProtocol.swift
+++ b/run-jin/Core/Protocols/AuthServiceProtocol.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Auth
+
+enum AuthState: Sendable {
+    case signedOut
+    case signedIn(User)
+}
+
+protocol AuthServiceProtocol: Sendable {
+    var currentUser: User? { get async }
+    var authStateStream: AsyncStream<AuthState> { get }
+
+    func signInWithPhone(phone: String) async throws
+    func verifyOTP(phone: String, code: String) async throws
+    func signInWithApple(idToken: String, nonce: String) async throws
+    func signOut() async throws
+}

--- a/run-jin/Services/AuthService.swift
+++ b/run-jin/Services/AuthService.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Auth
+import Supabase
+
+final class AuthService: AuthServiceProtocol {
+    var currentUser: User? {
+        get async {
+            try? await supabase.auth.session.user
+        }
+    }
+
+    var authStateStream: AsyncStream<AuthState> {
+        AsyncStream { continuation in
+            let task = Task {
+                for await (event, session) in supabase.auth.authStateChanges {
+                    switch event {
+                    case .signedIn:
+                        if let user = session?.user {
+                            continuation.yield(.signedIn(user))
+                        }
+                    case .signedOut:
+                        continuation.yield(.signedOut)
+                    default:
+                        break
+                    }
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    func signInWithPhone(phone: String) async throws {
+        try await supabase.auth.signInWithOTP(phone: phone)
+    }
+
+    func verifyOTP(phone: String, code: String) async throws {
+        try await supabase.auth.verifyOTP(
+            phone: phone,
+            token: code,
+            type: .sms
+        )
+    }
+
+    func signInWithApple(idToken: String, nonce: String) async throws {
+        try await supabase.auth.signInWithIdToken(
+            credentials: .init(provider: .apple, idToken: idToken, nonce: nonce)
+        )
+    }
+
+    func signOut() async throws {
+        try await supabase.auth.signOut()
+    }
+}

--- a/run-jin/Services/SupabaseService.swift
+++ b/run-jin/Services/SupabaseService.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Supabase
+
+enum SupabaseConfig {
+    static var url: URL {
+        guard let urlString = Bundle.main.infoDictionary?["SUPABASE_URL"] as? String,
+              let url = URL(string: urlString) else {
+            #if DEBUG
+            return URL(string: "http://127.0.0.1:54321")!
+            #else
+            fatalError("SUPABASE_URL not configured in Info.plist")
+            #endif
+        }
+        return url
+    }
+
+    static var anonKey: String {
+        guard let key = Bundle.main.infoDictionary?["SUPABASE_ANON_KEY"] as? String, !key.isEmpty else {
+            #if DEBUG
+            return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
+            #else
+            fatalError("SUPABASE_ANON_KEY not configured in Info.plist")
+            #endif
+        }
+        return key
+    }
+}
+
+let supabase = SupabaseClient(
+    supabaseURL: SupabaseConfig.url,
+    supabaseKey: SupabaseConfig.anonKey
+)


### PR DESCRIPTION
## Summary
- SupabaseClient シングルトン設定 (xcconfig経由でURL/anonKey取得)
- AuthServiceProtocol定義 (signIn, signOut, verifyOTP, Apple Sign-In)
- AuthService実装 (supabase-swift Auth使用)
- デバッグ時はlocalhostにフォールバック

Closes #6

## Test plan
- [x] `make build` 成功
- [ ] ローカルSupabaseに接続確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)