### PR TITLE
feat: define all SwiftData domain models

### DIFF
--- a/run-jin/Models/Domain/Achievement.swift
+++ b/run-jin/Models/Domain/Achievement.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Achievement {
+    @Attribute(.unique) var achievementId: String
+    var name: String
+    var descriptionText: String
+    var category: String
+    var icon: String
+    var unlockedAt: Date?
+
+    var isUnlocked: Bool {
+        unlockedAt != nil
+    }
+
+    init(
+        achievementId: String,
+        name: String,
+        descriptionText: String,
+        category: String,
+        icon: String = "star.fill",
+        unlockedAt: Date? = nil
+    ) {
+        self.achievementId = achievementId
+        self.name = name
+        self.descriptionText = descriptionText
+        self.category = category
+        self.icon = icon
+        self.unlockedAt = unlockedAt
+    }
+}

--- a/run-jin/Models/Domain/PrivacyZone.swift
+++ b/run-jin/Models/Domain/PrivacyZone.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SwiftData
+
+@Model
+final class PrivacyZone {
+    var id: UUID
+    var label: String
+    var centerLatitude: Double
+    var centerLongitude: Double
+    var radiusMeters: Int
+
+    init(
+        id: UUID = UUID(),
+        label: String = "",
+        centerLatitude: Double,
+        centerLongitude: Double,
+        radiusMeters: Int = 500
+    ) {
+        self.id = id
+        self.label = label
+        self.centerLatitude = centerLatitude
+        self.centerLongitude = centerLongitude
+        self.radiusMeters = radiusMeters
+    }
+}

--- a/run-jin/Models/Domain/RunLocation.swift
+++ b/run-jin/Models/Domain/RunLocation.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftData
+
+@Model
+final class RunLocation {
+    var latitude: Double
+    var longitude: Double
+    var altitude: Double
+    var timestamp: Date
+    var accuracy: Double
+    var speed: Double
+
+    var session: RunSession?
+
+    init(
+        latitude: Double,
+        longitude: Double,
+        altitude: Double = 0,
+        timestamp: Date = Date(),
+        accuracy: Double = 0,
+        speed: Double = 0
+    ) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.altitude = altitude
+        self.timestamp = timestamp
+        self.accuracy = accuracy
+        self.speed = speed
+    }
+}

--- a/run-jin/Models/Domain/RunSession.swift
+++ b/run-jin/Models/Domain/RunSession.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SwiftData
+
+@Model
+final class RunSession {
+    var id: UUID
+    var startedAt: Date
+    var endedAt: Date?
+    var distanceMeters: Double
+    var durationSeconds: Int
+    var avgPaceSecondsPerKm: Double?
+    var calories: Int?
+    var cellsCaptured: Int
+    var cellsOverridden: Int
+    var syncStatus: SyncStatus
+    var idempotencyKey: String
+
+    @Relationship(deleteRule: .cascade, inverse: \RunLocation.session)
+    var locations: [RunLocation]
+
+    init(
+        id: UUID = UUID(),
+        startedAt: Date = Date(),
+        endedAt: Date? = nil,
+        distanceMeters: Double = 0,
+        durationSeconds: Int = 0,
+        avgPaceSecondsPerKm: Double? = nil,
+        calories: Int? = nil,
+        cellsCaptured: Int = 0,
+        cellsOverridden: Int = 0,
+        syncStatus: SyncStatus = .pending,
+        idempotencyKey: String = UUID().uuidString,
+        locations: [RunLocation] = []
+    ) {
+        self.id = id
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.distanceMeters = distanceMeters
+        self.durationSeconds = durationSeconds
+        self.avgPaceSecondsPerKm = avgPaceSecondsPerKm
+        self.calories = calories
+        self.cellsCaptured = cellsCaptured
+        self.cellsOverridden = cellsOverridden
+        self.syncStatus = syncStatus
+        self.idempotencyKey = idempotencyKey
+        self.locations = locations
+    }
+}
+
+enum SyncStatus: String, Codable {
+    case pending
+    case synced
+    case conflict
+}

--- a/run-jin/Models/Domain/Team.swift
+++ b/run-jin/Models/Domain/Team.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Team {
+    @Attribute(.unique) var id: String
+    var name: String
+    var color: String
+    var inviteCode: String
+    var memberCount: Int
+    var totalCellsOwned: Int
+
+    init(
+        id: String = UUID().uuidString,
+        name: String,
+        color: String = "#007AFF",
+        inviteCode: String = "",
+        memberCount: Int = 0,
+        totalCellsOwned: Int = 0
+    ) {
+        self.id = id
+        self.name = name
+        self.color = color
+        self.inviteCode = inviteCode
+        self.memberCount = memberCount
+        self.totalCellsOwned = totalCellsOwned
+    }
+}

--- a/run-jin/Models/Domain/Territory.swift
+++ b/run-jin/Models/Domain/Territory.swift
@@ -1,0 +1,25 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Territory {
+    @Attribute(.unique) var h3Index: String
+    var ownerId: String?
+    var teamId: String?
+    var capturedAt: Date
+    var totalDistanceMeters: Double
+
+    init(
+        h3Index: String,
+        ownerId: String? = nil,
+        teamId: String? = nil,
+        capturedAt: Date = Date(),
+        totalDistanceMeters: Double = 0
+    ) {
+        self.h3Index = h3Index
+        self.ownerId = ownerId
+        self.teamId = teamId
+        self.capturedAt = capturedAt
+        self.totalDistanceMeters = totalDistanceMeters
+    }
+}

--- a/run-jin/Models/Domain/UserProfile.swift
+++ b/run-jin/Models/Domain/UserProfile.swift
@@ -1,0 +1,40 @@
+import Foundation
+import SwiftData
+
+@Model
+final class UserProfile {
+    @Attribute(.unique) var id: String
+    var displayName: String
+    var avatarURL: String?
+    var teamId: String?
+    var prefectureCode: Int?
+    var municipalityCode: Int?
+    var isPremium: Bool
+    var isAnonymous: Bool
+    var totalDistanceMeters: Double
+    var totalCellsOwned: Int
+
+    init(
+        id: String,
+        displayName: String = "",
+        avatarURL: String? = nil,
+        teamId: String? = nil,
+        prefectureCode: Int? = nil,
+        municipalityCode: Int? = nil,
+        isPremium: Bool = false,
+        isAnonymous: Bool = false,
+        totalDistanceMeters: Double = 0,
+        totalCellsOwned: Int = 0
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.avatarURL = avatarURL
+        self.teamId = teamId
+        self.prefectureCode = prefectureCode
+        self.municipalityCode = municipalityCode
+        self.isPremium = isPremium
+        self.isAnonymous = isAnonymous
+        self.totalDistanceMeters = totalDistanceMeters
+        self.totalCellsOwned = totalCellsOwned
+    }
+}

--- a/run-jin/run_jinApp.swift
+++ b/run-jin/run_jinApp.swift
@@ -5,9 +5,28 @@ import SwiftData
 struct run_jinApp: App {
     let container = DependencyContainer.shared
 
+    var sharedModelContainer: ModelContainer = {
+        let schema = Schema([
+            RunSession.self,
+            RunLocation.self,
+            Territory.self,
+            UserProfile.self,
+            Team.self,
+            Achievement.self,
+            PrivacyZone.self,
+        ])
+        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+        do {
+            return try ModelContainer(for: schema, configurations: [config])
+        } catch {
+            fatalError("Could not create ModelContainer: \(error)")
+        }
+    }()
+
     var body: some Scene {
         WindowGroup {
             TabBarView()
         }
+        .modelContainer(sharedModelContainer)
     }
 }


### PR DESCRIPTION
## Summary
- 全ドメインモデルをSwiftData @Modelで定義:
  RunSession, RunLocation, Territory, UserProfile, Team, Achievement, PrivacyZone
- ModelContainerに全スキーマ登録
- RunSession↔RunLocation のリレーションシップ設定

Closes #7

## Test plan
- [x] `make build` 成功
- [ ] Preview用inMemoryコンテナ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)