### PR TITLE
fix: allow GoogleService-Info.plist in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,6 @@ fastlane/test_output
 *.xcconfig
 !*.xcconfig.template
 
-# Firebase
-GoogleService-Info.plist
-
 # Supabase local
 supabase/.temp/
 supabase/.branches/


### PR DESCRIPTION
## Summary
- .gitignoreからGoogleService-Info.plistの除外を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)