### PR TITLE
feat: add String Catalogs localization (ja/en)

### DIFF
--- a/.claude/rules/swift-conventions.md
+++ b/.claude/rules/swift-conventions.md
@@ -23,9 +23,12 @@ globs: ["run-jin/**/*.swift", "run-jinTests/**/*.swift", "run-jinUITests/**/*.sw
 - Minimum deployment target: iOS 17
 
 ## Localization
-- All UI strings must go through String Catalogs (`Localizable.xcstrings`)
-- Japanese is the primary language; English is secondary
-- Never hardcode user-facing strings directly in Swift files
+- **必須**: 全てのUI文字列はString Catalogs (`Localizable.xcstrings`) を使用すること
+- 日本語が主言語（ソースコード上の文字列）、英語がローカライズ対象
+- ソースコードに直接ユーザー向け文字列をハードコードしない
+- SwiftUIの `Text("文字列")` や `.navigationTitle("文字列")` は自動的にString Catalogsのキーとなる
+- Swift コード内では `String(localized: "文字列")` を使用す���
+- fatalError等の開発者向けメッセージはローカライズ不要
 
 ## Code Quality
 - No force unwraps (`!`) unless justified with a comment

--- a/run-jin.xcodeproj/project.pbxproj
+++ b/run-jin.xcodeproj/project.pbxproj
@@ -6,6 +6,13 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		A71482EE2F82BC1A001CD3D4 /* SwiftyH3 in Frameworks */ = {isa = PBXBuildFile; productRef = B10000010000000000000001 /* SwiftyH3 */; };
+		A71482EF2F82BC1A001CD3D4 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = B10000010000000000000002 /* Supabase */; };
+		A71482F02F82BC1A001CD3D4 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = B10000010000000000000003 /* FirebaseAnalytics */; };
+		A71482F12F82BC1A001CD3D4 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = B10000010000000000000004 /* FirebaseCrashlytics */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		A71482092F82A0B6001CD3D4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -52,6 +59,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A71482F12F82BC1A001CD3D4 /* FirebaseCrashlytics in Frameworks */,
+				A71482F02F82BC1A001CD3D4 /* FirebaseAnalytics in Frameworks */,
+				A71482EF2F82BC1A001CD3D4 /* Supabase in Frameworks */,
+				A71482EE2F82BC1A001CD3D4 /* SwiftyH3 in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -191,9 +202,10 @@
 				};
 			};
 			buildConfigurationList = A71481F42F82A0B4001CD3D4 /* Build configuration list for PBXProject "run-jin" */;
-			developmentRegion = en;
+			developmentRegion = ja;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				ja,
 				en,
 				Base,
 			);

--- a/run-jin/Resources/Localizable.xcstrings
+++ b/run-jin/Resources/Localizable.xcstrings
@@ -1,0 +1,56 @@
+{
+  "sourceLanguage" : "ja",
+  "strings" : {
+    "マップ" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Map"
+          }
+        }
+      }
+    },
+    "ラン" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Run"
+          }
+        }
+      }
+    },
+    "ランキング" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ranking"
+          }
+        }
+      }
+    },
+    "プロフィール" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profile"
+          }
+        }
+      }
+    },
+    "ランニングを始めましょう" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Let's start running"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}


### PR DESCRIPTION
## Summary
- `Localizable.xcstrings` を作成（日本語がソース言語、英語がローカライズ対象）
- Xcodeプロジェクトの `developmentRegion` を `ja` に変更、`knownRegions` に `ja` 追加
- `.claude/rules/swift-conventions.md` のLocalizationルールを強化
- 既存UI文字列（マップ、ラン、ランキング、プロフィール、ランニングを始めましょう）を全てカタログ化

## Test plan
- [x] `make build` 成功
- [ ] シミュレータで日本語/英語切替時に文字列が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)