### PR TITLE
chore: disable CI auto-trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 name: CI
 
-on:
-  push:
-    branches: [main]
+# Disabled until Xcode 26 / iOS 26 runners are available on GitHub Actions
+# on:
+#   push:
+#     branches: [main]
+
+on: workflow_dispatch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- CIトリガーを `push` から `workflow_dispatch`（手動実行のみ）に変更
- GitHub Actions の macos-15 ランナーに Xcode 26 / iOS 26 SDK がないため

## Test plan
- [x] push時にCIが実行されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)