### PR TITLE
feat: add team (guild) functionality (#23)

### DIFF
--- a/run-jin/Repositories/TeamRepository.swift
+++ b/run-jin/Repositories/TeamRepository.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Supabase
+
+// MARK: - DTO
+
+struct TeamDTO: Codable, Sendable {
+    let id: String
+    let name: String
+    let color: String
+    let inviteCode: String
+    let memberCount: Int
+    let totalCellsOwned: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case color
+        case inviteCode = "invite_code"
+        case memberCount = "member_count"
+        case totalCellsOwned = "total_cells_owned"
+    }
+}
+
+struct TeamMemberDTO: Codable, Sendable {
+    let id: String
+    let displayName: String
+    let totalCellsOwned: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case displayName = "display_name"
+        case totalCellsOwned = "total_cells_owned"
+    }
+}
+
+struct CreateTeamRequest: Codable, Sendable {
+    let name: String
+    let color: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case color
+    }
+}
+
+struct JoinTeamRequest: Codable, Sendable {
+    let teamId: String
+
+    enum CodingKeys: String, CodingKey {
+        case teamId = "team_id"
+    }
+}
+
+// MARK: - Protocol
+
+protocol TeamRepositoryProtocol: Sendable {
+    func fetchTeam(id: String) async throws -> TeamDTO
+    func fetchTeamByInviteCode(_ code: String) async throws -> TeamDTO
+    func createTeam(name: String, color: String) async throws -> TeamDTO
+    func joinTeam(teamId: String) async throws
+    func leaveTeam() async throws
+    func fetchMembers(teamId: String) async throws -> [TeamMemberDTO]
+}
+
+// MARK: - Implementation
+
+final class TeamRepository: TeamRepositoryProtocol {
+    func fetchTeam(id: String) async throws -> TeamDTO {
+        try await supabase
+            .from("teams")
+            .select()
+            .eq("id", value: id)
+            .single()
+            .execute()
+            .value
+    }
+
+    func fetchTeamByInviteCode(_ code: String) async throws -> TeamDTO {
+        try await supabase
+            .from("teams")
+            .select()
+            .eq("invite_code", value: code)
+            .single()
+            .execute()
+            .value
+    }
+
+    func createTeam(name: String, color: String) async throws -> TeamDTO {
+        let request = CreateTeamRequest(name: name, color: color)
+        return try await supabase
+            .from("teams")
+            .insert(request)
+            .select()
+            .single()
+            .execute()
+            .value
+    }
+
+    func joinTeam(teamId: String) async throws {
+        let userId = try await supabase.auth.session.user.id.uuidString
+        try await supabase
+            .from("user_profiles")
+            .update(JoinTeamRequest(teamId: teamId))
+            .eq("id", value: userId)
+            .execute()
+    }
+
+    func leaveTeam() async throws {
+        let userId = try await supabase.auth.session.user.id.uuidString
+        struct ClearTeam: Codable {
+            let teamId: String?
+            enum CodingKeys: String, CodingKey {
+                case teamId = "team_id"
+            }
+        }
+        try await supabase
+            .from("user_profiles")
+            .update(ClearTeam(teamId: nil))
+            .eq("id", value: userId)
+            .execute()
+    }
+
+    func fetchMembers(teamId: String) async throws -> [TeamMemberDTO] {
+        try await supabase
+            .from("user_profiles")
+            .select("id, display_name, total_cells_owned")
+            .eq("team_id", value: teamId)
+            .execute()
+            .value
+    }
+}

--- a/run-jin/ViewModels/TeamViewModel.swift
+++ b/run-jin/ViewModels/TeamViewModel.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+@MainActor
+@Observable
+final class TeamViewModel {
+    // MARK: - State
+
+    var team: TeamDTO?
+    var members: [TeamMemberDTO] = []
+    var isLoading = false
+    var errorMessage: String?
+
+    // Create form
+    var newTeamName = ""
+    var newTeamColor = "#007AFF"
+
+    // Join form
+    var inviteCode = ""
+
+    var hasTeam: Bool { team != nil }
+
+    var totalTeamCells: Int {
+        members.reduce(0) { $0 + $1.totalCellsOwned }
+    }
+
+    // MARK: - Dependencies
+
+    private let repository: any TeamRepositoryProtocol
+
+    nonisolated init(repository: any TeamRepositoryProtocol = TeamRepository()) {
+        self.repository = repository
+    }
+
+    // MARK: - Actions
+
+    func loadTeam(teamId: String) async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            team = try await repository.fetchTeam(id: teamId)
+            if let team {
+                members = try await repository.fetchMembers(teamId: team.id)
+            }
+        } catch {
+            errorMessage = String(localized: "チーム情報の取得に失敗しました")
+        }
+        isLoading = false
+    }
+
+    func createTeam() async {
+        guard !newTeamName.trimmingCharacters(in: .whitespaces).isEmpty else {
+            errorMessage = String(localized: "チーム名を入力してください")
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+        do {
+            let created = try await repository.createTeam(
+                name: newTeamName.trimmingCharacters(in: .whitespaces),
+                color: newTeamColor
+            )
+            try await repository.joinTeam(teamId: created.id)
+            team = created
+            members = try await repository.fetchMembers(teamId: created.id)
+            newTeamName = ""
+        } catch {
+            errorMessage = String(localized: "チームの作成に失敗しました")
+        }
+        isLoading = false
+    }
+
+    func joinTeamWithInviteCode() async {
+        guard !inviteCode.trimmingCharacters(in: .whitespaces).isEmpty else {
+            errorMessage = String(localized: "招待コードを入力してください")
+            return
+        }
+
+        isLoading = true
+        errorMessage = nil
+        do {
+            let found = try await repository.fetchTeamByInviteCode(
+                inviteCode.trimmingCharacters(in: .whitespaces)
+            )
+            try await repository.joinTeam(teamId: found.id)
+            team = found
+            members = try await repository.fetchMembers(teamId: found.id)
+            inviteCode = ""
+        } catch {
+            errorMessage = String(localized: "チームへの参加に失敗しました。招待コードを確認してください")
+        }
+        isLoading = false
+    }
+
+    func leaveTeam() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            try await repository.leaveTeam()
+            team = nil
+            members = []
+        } catch {
+            errorMessage = String(localized: "チームの退出に失敗しました")
+        }
+        isLoading = false
+    }
+}

--- a/run-jin/Views/TeamCreateView.swift
+++ b/run-jin/Views/TeamCreateView.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+struct TeamCreateView: View {
+    @State var viewModel = TeamViewModel()
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedTab = 0
+
+    private let teamColors: [(name: String, hex: String)] = [
+        ("青", "#007AFF"),
+        ("赤", "#FF3B30"),
+        ("緑", "#34C759"),
+        ("オレンジ", "#FF9500"),
+        ("紫", "#AF52DE"),
+        ("ピンク", "#FF2D55"),
+        ("黄", "#FFCC00"),
+        ("水色", "#5AC8FA"),
+    ]
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Picker("", selection: $selectedTab) {
+                    Text("チーム作成").tag(0)
+                    Text("チーム参加").tag(1)
+                }
+                .pickerStyle(.segmented)
+                .padding()
+
+                if selectedTab == 0 {
+                    createTeamForm
+                } else {
+                    joinTeamForm
+                }
+
+                Spacer()
+            }
+            .navigationTitle("チーム")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("閉じる") {
+                        dismiss()
+                    }
+                }
+            }
+            .alert("エラー", isPresented: .constant(viewModel.errorMessage != nil)) {
+                Button("OK") {
+                    viewModel.errorMessage = nil
+                }
+            } message: {
+                if let message = viewModel.errorMessage {
+                    Text(message)
+                }
+            }
+            .onChange(of: viewModel.hasTeam) { _, hasTeam in
+                if hasTeam {
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    // MARK: - Create Team Form
+
+    private var createTeamForm: some View {
+        Form {
+            Section("チーム名") {
+                TextField("チーム名を入力", text: $viewModel.newTeamName)
+                    .textContentType(.organizationName)
+            }
+
+            Section("チームカラー") {
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 4), spacing: 12) {
+                    ForEach(teamColors, id: \.hex) { color in
+                        colorButton(name: color.name, hex: color.hex)
+                    }
+                }
+                .padding(.vertical, 8)
+            }
+
+            Section {
+                Button {
+                    Task {
+                        await viewModel.createTeam()
+                    }
+                } label: {
+                    HStack {
+                        Spacer()
+                        if viewModel.isLoading {
+                            ProgressView()
+                        } else {
+                            Text("チームを作成する")
+                                .fontWeight(.semibold)
+                        }
+                        Spacer()
+                    }
+                }
+                .disabled(viewModel.newTeamName.trimmingCharacters(in: .whitespaces).isEmpty || viewModel.isLoading)
+            }
+        }
+    }
+
+    // MARK: - Join Team Form
+
+    private var joinTeamForm: some View {
+        Form {
+            Section("招待コード") {
+                TextField("招待コードを入力", text: $viewModel.inviteCode)
+                    .textInputAutocapitalization(.characters)
+                    .autocorrectionDisabled()
+            }
+
+            Section {
+                Button {
+                    Task {
+                        await viewModel.joinTeamWithInviteCode()
+                    }
+                } label: {
+                    HStack {
+                        Spacer()
+                        if viewModel.isLoading {
+                            ProgressView()
+                        } else {
+                            Text("チームに参加する")
+                                .fontWeight(.semibold)
+                        }
+                        Spacer()
+                    }
+                }
+                .disabled(viewModel.inviteCode.trimmingCharacters(in: .whitespaces).isEmpty || viewModel.isLoading)
+            }
+        }
+    }
+
+    // MARK: - Color Picker
+
+    @ViewBuilder
+    private func colorButton(name: String, hex: String) -> some View {
+        Button {
+            viewModel.newTeamColor = hex
+        } label: {
+            VStack(spacing: 4) {
+                Circle()
+                    .fill(Color(hex: hex))
+                    .frame(width: 44, height: 44)
+                    .overlay {
+                        if viewModel.newTeamColor == hex {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.white)
+                                .fontWeight(.bold)
+                        }
+                    }
+                Text(name)
+                    .font(.caption2)
+                    .foregroundStyle(.primary)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    TeamCreateView()
+}

--- a/run-jin/Views/TeamDetailView.swift
+++ b/run-jin/Views/TeamDetailView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct TeamDetailView: View {
+    @State var viewModel = TeamViewModel()
+
+    let teamId: String
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading && viewModel.team == nil {
+                ProgressView("読み込み中...")
+            } else if let team = viewModel.team {
+                teamContent(team)
+            } else {
+                ContentUnavailableView(
+                    "チーム情報なし",
+                    systemImage: "person.3.fill",
+                    description: Text("チーム情報を取得できませんでした")
+                )
+            }
+        }
+        .navigationTitle("チーム")
+        .task {
+            await viewModel.loadTeam(teamId: teamId)
+        }
+        .alert("エラー", isPresented: .constant(viewModel.errorMessage != nil)) {
+            Button("OK") {
+                viewModel.errorMessage = nil
+            }
+        } message: {
+            if let message = viewModel.errorMessage {
+                Text(message)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func teamContent(_ team: TeamDTO) -> some View {
+        List {
+            Section {
+                HStack {
+                    Circle()
+                        .fill(Color(hex: team.color))
+                        .frame(width: 40, height: 40)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(team.name)
+                            .font(.title2)
+                            .fontWeight(.bold)
+                        Text("招待コード: \(team.inviteCode)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+
+            Section("チーム統計") {
+                LabeledContent("メンバー数") {
+                    Text("\(viewModel.members.count)")
+                }
+                LabeledContent("合計セル数") {
+                    Text("\(viewModel.totalTeamCells)")
+                }
+            }
+
+            Section("メンバー") {
+                if viewModel.members.isEmpty {
+                    Text("メンバーがいません")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(viewModel.members, id: \.id) { member in
+                        HStack {
+                            Image(systemName: "person.circle.fill")
+                                .foregroundStyle(.secondary)
+                                .font(.title3)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(member.displayName.isEmpty
+                                     ? String(localized: "名無しランナー")
+                                     : member.displayName)
+                                    .font(.body)
+                                Text("\(member.totalCellsOwned) セル")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                        }
+                    }
+                }
+            }
+
+            Section {
+                Button(role: .destructive) {
+                    Task {
+                        await viewModel.leaveTeam()
+                    }
+                } label: {
+                    HStack {
+                        Spacer()
+                        Text("チームを退出する")
+                        Spacer()
+                    }
+                }
+                .disabled(viewModel.isLoading)
+            }
+        }
+    }
+}
+
+// MARK: - Color Extension
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet(charactersIn: "#"))
+        let scanner = Scanner(string: hex)
+        var rgbValue: UInt64 = 0
+        scanner.scanHexInt64(&rgbValue)
+
+        let r = Double((rgbValue & 0xFF0000) >> 16) / 255.0
+        let g = Double((rgbValue & 0x00FF00) >> 8) / 255.0
+        let b = Double(rgbValue & 0x0000FF) / 255.0
+
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TeamDetailView(teamId: "preview-id")
+    }
+}


### PR DESCRIPTION
Closes #23

## Summary
- **TeamRepository** (`run-jin/Repositories/TeamRepository.swift`): Protocol-based repository for team CRUD via Supabase — create team, join by invite code, leave team, fetch members
- **TeamViewModel** (`run-jin/ViewModels/TeamViewModel.swift`): `@MainActor @Observable` ViewModel managing team state, create/join/leave actions, and form validation
- **TeamDetailView** (`run-jin/Views/TeamDetailView.swift`): Displays team info (name, color, invite code), member list with cell counts, team stats, and leave button
- **TeamCreateView** (`run-jin/Views/TeamCreateView.swift`): Segmented form for creating a team (name + 8-color picker) or joining via invite code

## Architecture
- Follows MVVM + Repository pattern per project conventions
- All UI strings in Japanese (String Catalogs convention)
- Protocol-based `TeamRepositoryProtocol` for testability/DI
- DTOs with snake_case CodingKeys for Supabase compatibility

## Test plan
- [ ] Build succeeds (`make build` passes)
- [ ] Create team with name and color — verify team appears in Supabase `teams` table
- [ ] Join team via invite code — verify `user_profiles.team_id` is updated
- [ ] Leave team — verify `user_profiles.team_id` is set to null
- [ ] Member list loads correctly for a team
- [ ] Color picker selects and displays correctly
- [ ] Error messages display in Japanese for validation failures
- [ ] Empty team name / invite code shows validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)