### PR TITLE
feat: add ad display for post-run screen

### DIFF
--- a/run-jin/Core/Protocols/AdServiceProtocol.swift
+++ b/run-jin/Core/Protocols/AdServiceProtocol.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Ad format types supported by the app.
+enum AdFormat: Sendable {
+    case banner
+    case interstitial
+}
+
+/// Protocol for ad loading and display services.
+/// Premium users bypass ads entirely; this is checked at the call site.
+protocol AdServiceProtocol: Sendable {
+    /// Whether an ad of the given format is ready to display.
+    func isAdReady(_ format: AdFormat) async -> Bool
+
+    /// Preload an ad for the given format.
+    func loadAd(_ format: AdFormat) async throws
+
+    /// Record that an ad impression was shown.
+    func recordImpression(_ format: AdFormat) async
+}

--- a/run-jin/Services/AdService.swift
+++ b/run-jin/Services/AdService.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Placeholder ad service implementation.
+/// Replace the body of each method with Google AdMob SDK calls when integrating.
+final class AdService: AdServiceProtocol {
+    // MARK: - State
+
+    private let loadedAds: NSMutableSet = .init()
+
+    // MARK: - AdServiceProtocol
+
+    func isAdReady(_ format: AdFormat) async -> Bool {
+        loadedAds.contains(format)
+    }
+
+    func loadAd(_ format: AdFormat) async throws {
+        // TODO: Replace with GADInterstitialAd.load / GADBannerView preload
+        // Simulate network delay for realistic placeholder behavior
+        try await Task.sleep(for: .milliseconds(300))
+        loadedAds.add(format)
+    }
+
+    func recordImpression(_ format: AdFormat) async {
+        // TODO: Replace with AdMob impression tracking
+        #if DEBUG
+        print("[AdService] Recorded impression for \(format)")
+        #endif
+    }
+}

--- a/run-jin/Views/AdBannerView.swift
+++ b/run-jin/Views/AdBannerView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Placeholder banner ad view.
+/// Replace with a `UIViewRepresentable` wrapping `GADBannerView` when AdMob is integrated.
+struct AdBannerView: View {
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(.systemGray5))
+
+            Text("広告")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(height: 50)
+        .padding(.horizontal)
+    }
+}
+
+#Preview {
+    AdBannerView()
+}

--- a/run-jin/Views/PostRunAdView.swift
+++ b/run-jin/Views/PostRunAdView.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// Full-screen interstitial-style ad shown after a run completes.
+/// Non-premium users see this view; premium users skip it entirely.
+struct PostRunAdView: View {
+    /// Called when the user dismisses the ad (after the countdown expires).
+    var onDismiss: () -> Void
+
+    // MARK: - Private State
+
+    @State private var remainingSeconds: Int = 5
+    @State private var canClose: Bool = false
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.85)
+                .ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                Spacer()
+
+                // Placeholder ad content area
+                ZStack {
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(Color(.systemGray5))
+                        .frame(width: 300, height: 250)
+
+                    Text("広告")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                // Close / countdown button
+                if canClose {
+                    Button {
+                        onDismiss()
+                    } label: {
+                        Text("閉じる")
+                            .font(.headline)
+                            .padding(.horizontal, 32)
+                            .padding(.vertical, 12)
+                            .background(.white)
+                            .foregroundStyle(.black)
+                            .clipShape(Capsule())
+                    }
+                } else {
+                    Text("\(remainingSeconds)秒後に閉じられます")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+            }
+            .padding(.bottom, 48)
+        }
+        .task {
+            await startCountdown()
+        }
+    }
+
+    // MARK: - Private
+
+    private func startCountdown() async {
+        for _ in 0..<5 {
+            try? await Task.sleep(for: .seconds(1))
+            remainingSeconds -= 1
+        }
+        canClose = true
+    }
+}
+
+#Preview {
+    PostRunAdView(onDismiss: {})
+}


### PR DESCRIPTION
Closes #31

## Summary
- Add `AdServiceProtocol` in `Core/Protocols/` defining ad loading, readiness check, and impression tracking
- Add placeholder `AdService` implementation in `Services/` ready for Google AdMob SDK integration
- Add `AdBannerView` — placeholder banner showing "広告" in a gray rounded rect
- Add `PostRunAdView` — full-screen interstitial ad view with 5-second countdown before close button appears
- Premium users bypass ads entirely (checked at call site)
- All UI strings in Japanese per project conventions

## Test plan
- [x] `make build` passes (BUILD SUCCEEDED)
- [ ] Verify `AdBannerView` renders gray placeholder with "広告" text in preview
- [ ] Verify `PostRunAdView` shows countdown from 5, then reveals "閉じる" button
- [ ] Verify `onDismiss` callback fires when close button is tapped
- [ ] Confirm no force unwraps or hardcoded secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)