### PR TITLE
feat: add Info.plist privacy and background mode settings

### DIFF
--- a/run-jin.xcodeproj/project.pbxproj
+++ b/run-jin.xcodeproj/project.pbxproj
@@ -422,8 +422,13 @@
 				DEVELOPMENT_TEAM = 85693DB6BF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "バックグラウンドでもランニングルートを正確に記録するために位置情報を使用します";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "ランニング中のルート記録と陣地獲得に位置情報を使用します";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "ランニング結果のスクリーンショットを保存するために使用します";
+				INFOPLIST_KEY_NSUserTrackingUsageDescription = "パーソナライズされた広告の表示に使用します";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = location;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -455,8 +460,13 @@
 				DEVELOPMENT_TEAM = 85693DB6BF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "バックグラウンドでもランニングルートを正確に記録するために位置情報を使用します";
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "ランニング中のルート記録と陣地獲得に位置情報を使用します";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "ランニング結果のスクリーンショットを保存するために使用します";
+				INFOPLIST_KEY_NSUserTrackingUsageDescription = "パーソナライズされた広告の表示に使用します";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = location;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";


### PR DESCRIPTION
Closes #39

## Summary
- Add `INFOPLIST_KEY_NSLocationWhenInUseUsageDescription` and `INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription` for location permissions
- Add `INFOPLIST_KEY_NSUserTrackingUsageDescription` for ATT compliance
- Add `INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription` for screenshot saving
- Add `INFOPLIST_KEY_UIBackgroundModes = location` for background GPS tracking
- Applied to both Debug and Release build configurations

## Approach
Since the project uses `GENERATE_INFOPLIST_FILE = YES`, settings are added as `INFOPLIST_KEY_` build settings in `project.pbxproj` rather than a separate Info.plist file.

## Test plan
- [ ] Verify project opens in Xcode without errors
- [ ] Build the app and check that Info.plist contains all expected keys
- [ ] Confirm location permission dialogs show correct Japanese text
- [ ] Confirm background location mode is active during runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)