### PR TITLE
fix: reset run session state after finishing a run

### DIFF
--- a/run-jin/Services/RunSessionService.swift
+++ b/run-jin/Services/RunSessionService.swift
@@ -118,6 +118,11 @@ final class RunSessionService: RunSessionServiceProtocol {
         let result = session
         self.session = nil
         state = .idle
+        currentStats = RunStats()
+        routeCoordinates = []
+        collectedLocations = []
+        pausedDuration = 0
+        startTime = nil
 
         return result
     }

--- a/run-jin/Views/TabBarView.swift
+++ b/run-jin/Views/TabBarView.swift
@@ -43,7 +43,7 @@ struct TabBarView: View {
                         switch route {
                         case .runHistory:
                             RunHistoryView()
-                        case .runDetail:
+                        case .runDetail(_):
                             Text("ラン詳細")
                         default:
                             EmptyView()

--- a/run-jinTests/RunSessionServiceTests.swift
+++ b/run-jinTests/RunSessionServiceTests.swift
@@ -72,4 +72,34 @@ struct RunSessionServiceTests {
         #expect(session != nil)
         #expect(session?.distanceMeters == 0)
     }
+
+    @Test @MainActor func finishResetsState() async throws {
+        let mockLocation = MockLocationService()
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: RunSession.self, RunLocation.self,
+            configurations: config
+        )
+        let context = container.mainContext
+
+        let service = RunSessionService(
+            locationService: mockLocation,
+            modelContext: context
+        )
+
+        await service.start()
+        #expect(service.state == .running)
+
+        // 少し待ってタイマーを進める
+        try await Task.sleep(for: .milliseconds(100))
+
+        let _ = await service.finish()
+
+        // finish後にすべてのステートがリセットされていることを確認
+        #expect(service.state == .idle)
+        #expect(service.currentStats.durationSeconds == 0)
+        #expect(service.currentStats.distanceMeters == 0)
+        #expect(service.currentStats.calories == 0)
+        #expect(service.routeCoordinates.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- **タイマーリセットバグ修正**: `RunSessionService.finish()` で `currentStats`, `routeCoordinates`, `collectedLocations`, `pausedDuration`, `startTime` をリセットするように修正。ラン終了後にUIが正しくゼロ表示に戻る
- **Route パターンマッチング修正**: `TabBarView` の `case .runDetail:` を `case .runDetail(_):` に修正し、associated value を明示的に処理
- **リグレッションテスト追加**: `finishResetsState` テストで finish() 後のステートリセットを検証

## Test Plan
- [x] `make build` 成功
- [x] `make test` 全テスト通過 (新規テスト含む)
- [x] Simulator でラン開始→終了→タイマーがリセットされることを確認

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)