### PR TITLE
fix: request location permission on map tab

### DIFF
--- a/run-jin/ViewModels/MapViewModel.swift
+++ b/run-jin/ViewModels/MapViewModel.swift
@@ -8,7 +8,12 @@ import SwiftUI
 final class MapViewModel {
     private let h3Service: H3ServiceProtocol
 
-    var cameraPosition: MapCameraPosition = .userLocation(fallback: .automatic)
+    var cameraPosition: MapCameraPosition = .userLocation(fallback: .region(
+        MKCoordinateRegion(
+            center: CLLocationCoordinate2D(latitude: 35.68, longitude: 139.69),
+            span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+        )
+    ))
     var visibleTerritories: [TerritoryOverlay] = []
 
     private var currentUserId: String?

--- a/run-jin/Views/MapTabView.swift
+++ b/run-jin/Views/MapTabView.swift
@@ -7,6 +7,7 @@ struct MapTabView: View {
     @State private var viewModel: MapViewModel?
 
     private let h3Service = H3Service()
+    private let locationService = DependencyContainer.shared.locationService
 
     var body: some View {
         Group {
@@ -18,6 +19,7 @@ struct MapTabView: View {
         }
         .navigationTitle("マップ")
         .onAppear {
+            locationService.requestWhenInUseAuthorization()
             if viewModel == nil {
                 viewModel = MapViewModel(h3Service: h3Service)
             }


### PR DESCRIPTION
## Summary
- MapTabViewの`onAppear`で`requestWhenInUseAuthorization()`を呼び出し、位置情報許可をリクエスト
- マップカメラのフォールバックを`.automatic`（世界全体）から東京中心のリージョンに変更

## Root Cause
`LocationService.requestWhenInUseAuthorization()`がアプリ内のどこからも呼ばれておらず、MapKitがユーザー位置を取得できなかった。

## Test Plan
- [ ] シミュレータで起動し、マップタブで位置情報許可ダイアログが表示される
- [ ] 許可後にユーザー位置（青い点）が表示され、マップがユーザー位置にズームする
- [ ] 許可前でも日本のマップが表示される（世界全体ではない）
- [ ] `make build` ✅
- [ ] `make test` ✅

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)