### PR TITLE
feat: add HealthKit integration

### DIFF
--- a/run-jin.xcodeproj/project.pbxproj
+++ b/run-jin.xcodeproj/project.pbxproj
@@ -422,6 +422,8 @@
 				DEVELOPMENT_TEAM = 85693DB6BF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "心拍数と体重を読み込み、カロリー計算とラン記録の精度を向上させるために使用します";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "完了したランニングをワークアウトとしてヘルスケアに保存するために使用します";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "バックグラウンドでもランニングルートを正確に記録するために位置情報を使用します";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "ランニング中のルート記録と陣地獲得に位置情報を使用します";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "ランニング結果のスクリーンショットを保存するために使用します";
@@ -461,6 +463,8 @@
 				DEVELOPMENT_TEAM = 85693DB6BF;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "心拍数と体重を読み込み、カロリー計算とラン記録の精度を向上させるために使用します";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "完了したランニングをワークアウトとしてヘルスケアに保存するために使用します";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "バックグラウンドでもランニングルートを正確に記録するために位置情報を使用します";
 				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "ランニング中のルート記録と陣地獲得に位置情報を使用します";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "ランニング結果のスクリーンショットを保存するために使用します";

--- a/run-jin/App/DependencyContainer.swift
+++ b/run-jin/App/DependencyContainer.swift
@@ -9,6 +9,7 @@ final class DependencyContainer: @unchecked Sendable {
 
     private var _authService: (any AuthServiceProtocol)?
     private var _locationService: LocationServiceProtocol?
+    private var _healthKitService: HealthKitServiceProtocol?
     private var _runSessionService: RunSessionService?
     private var _storeKitService: StoreKitServiceProtocol?
     private var _voiceFeedbackService: VoiceFeedbackServiceProtocol?
@@ -25,6 +26,13 @@ final class DependencyContainer: @unchecked Sendable {
             _locationService = LocationService()
         }
         return _locationService!
+    }
+
+    var healthKitService: HealthKitServiceProtocol {
+        if _healthKitService == nil {
+            _healthKitService = HealthKitService()
+        }
+        return _healthKitService!
     }
 
     var voiceFeedbackService: VoiceFeedbackServiceProtocol {
@@ -46,6 +54,7 @@ final class DependencyContainer: @unchecked Sendable {
         if _runSessionService == nil {
             _runSessionService = RunSessionService(
                 locationService: locationService,
+                healthKitService: healthKitService,
                 modelContext: modelContext
             )
         }

--- a/run-jin/Core/Protocols/HealthKitServiceProtocol.swift
+++ b/run-jin/Core/Protocols/HealthKitServiceProtocol.swift
@@ -1,0 +1,39 @@
+import CoreLocation
+import Foundation
+
+enum HealthKitAuthorizationStatus: Sendable, Equatable {
+    case notDetermined
+    case sharingDenied
+    case sharingAuthorized
+    case notAvailable
+}
+
+struct HealthKitHeartRateSummary: Sendable, Equatable {
+    let avgBpm: Int
+    let maxBpm: Int
+}
+
+/// `RunSession` (SwiftData @Model) は Sendable ではないため、HealthKit書き込み用に値型のスナップショットを渡す
+struct WorkoutWriteData: Sendable, Equatable {
+    let startDate: Date
+    let endDate: Date
+    let distanceMeters: Double
+    let calories: Int?
+}
+
+enum HealthKitError: Error, Sendable {
+    case notAvailable
+    case writeFailed(String)
+    case queryFailed(String)
+}
+
+protocol HealthKitServiceProtocol: Sendable {
+    var isHealthDataAvailable: Bool { get }
+    var writeAuthorizationStatus: HealthKitAuthorizationStatus { get }
+
+    func requestAuthorization() async throws
+    func refreshAuthorizationStatus()
+    func fetchLatestBodyMassKg() async -> Double?
+    func fetchHeartRateSummary(start: Date, end: Date) async -> HealthKitHeartRateSummary?
+    func writeWorkout(_ workout: WorkoutWriteData, locations: [CLLocation]) async throws
+}

--- a/run-jin/Models/DTO/RunSessionDTO.swift
+++ b/run-jin/Models/DTO/RunSessionDTO.swift
@@ -9,6 +9,8 @@ struct RunSessionDTO: Codable, Sendable {
     let durationSeconds: Int
     let avgPaceSecondsPerKm: Double?
     let calories: Int?
+    let avgHeartRate: Int?
+    let maxHeartRate: Int?
     let route: String? // PostGIS WKT形式 LINESTRING
     let cellsCaptured: Int
     let cellsOverridden: Int
@@ -23,6 +25,8 @@ struct RunSessionDTO: Codable, Sendable {
         case durationSeconds = "duration_seconds"
         case avgPaceSecondsPerKm = "avg_pace_seconds_per_km"
         case calories
+        case avgHeartRate = "avg_heart_rate"
+        case maxHeartRate = "max_heart_rate"
         case route
         case cellsCaptured = "cells_captured"
         case cellsOverridden = "cells_overridden"
@@ -49,6 +53,8 @@ extension RunSessionDTO {
             durationSeconds: session.durationSeconds,
             avgPaceSecondsPerKm: session.avgPaceSecondsPerKm,
             calories: session.calories,
+            avgHeartRate: session.avgHeartRate,
+            maxHeartRate: session.maxHeartRate,
             route: route,
             cellsCaptured: session.cellsCaptured,
             cellsOverridden: session.cellsOverridden,

--- a/run-jin/Models/Domain/RunSession.swift
+++ b/run-jin/Models/Domain/RunSession.swift
@@ -10,6 +10,8 @@ final class RunSession {
     var durationSeconds: Int
     var avgPaceSecondsPerKm: Double?
     var calories: Int?
+    var avgHeartRate: Int?
+    var maxHeartRate: Int?
     var cellsCaptured: Int
     var cellsOverridden: Int
     var syncStatus: SyncStatus
@@ -26,6 +28,8 @@ final class RunSession {
         durationSeconds: Int = 0,
         avgPaceSecondsPerKm: Double? = nil,
         calories: Int? = nil,
+        avgHeartRate: Int? = nil,
+        maxHeartRate: Int? = nil,
         cellsCaptured: Int = 0,
         cellsOverridden: Int = 0,
         syncStatus: SyncStatus = .pending,
@@ -39,6 +43,8 @@ final class RunSession {
         self.durationSeconds = durationSeconds
         self.avgPaceSecondsPerKm = avgPaceSecondsPerKm
         self.calories = calories
+        self.avgHeartRate = avgHeartRate
+        self.maxHeartRate = maxHeartRate
         self.cellsCaptured = cellsCaptured
         self.cellsOverridden = cellsOverridden
         self.syncStatus = syncStatus

--- a/run-jin/Resources/Localizable.xcstrings
+++ b/run-jin/Resources/Localizable.xcstrings
@@ -1950,6 +1950,116 @@
           }
         }
       }
+    },
+    "ステータス" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
+          }
+        }
+      }
+    },
+    "拒否" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denied"
+          }
+        }
+      }
+    },
+    "許可済み" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authorized"
+          }
+        }
+      }
+    },
+    "未設定" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Determined"
+          }
+        }
+      }
+    },
+    "利用不可" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unavailable"
+          }
+        }
+      }
+    },
+    "このデバイスでは利用できません" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not Available on This Device"
+          }
+        }
+      }
+    },
+    "ヘルスケア連携" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Health App"
+          }
+        }
+      }
+    },
+    "ヘルスケアへのアクセスを許可" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Allow Access to Health"
+          }
+        }
+      }
+    },
+    "ヘルスケアへのアクセスが拒否されています。設定アプリから変更できます。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Health access is denied. You can change it in the Settings app."
+          }
+        }
+      }
+    },
+    "ワークアウトの書き込み、心拍数と体重の読み込みに使用します。拒否してもランニングの記録は通常通り行えます。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Used to write workouts and read heart rate and body mass. Runs are still recorded normally if denied."
+          }
+        }
+      }
+    },
+    "設定アプリで変更" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Change in Settings"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/run-jin/Services/HealthKitService.swift
+++ b/run-jin/Services/HealthKitService.swift
@@ -1,0 +1,177 @@
+import CoreLocation
+import Foundation
+import HealthKit
+import os
+
+final class HealthKitService: HealthKitServiceProtocol, @unchecked Sendable {
+    private let healthStore = HKHealthStore()
+    private let logger = Logger(subsystem: "app.space.k1t.run-jin", category: "HealthKitService")
+
+    private let _writeAuthorizationStatus: OSAllocatedUnfairLock<HealthKitAuthorizationStatus>
+
+    var isHealthDataAvailable: Bool {
+        HKHealthStore.isHealthDataAvailable()
+    }
+
+    var writeAuthorizationStatus: HealthKitAuthorizationStatus {
+        _writeAuthorizationStatus.withLock { $0 }
+    }
+
+    init() {
+        let initial: HealthKitAuthorizationStatus = HKHealthStore.isHealthDataAvailable() ? .notDetermined : .notAvailable
+        self._writeAuthorizationStatus = OSAllocatedUnfairLock(initialState: initial)
+        if HKHealthStore.isHealthDataAvailable() {
+            updateAuthorizationStatusFromStore()
+        }
+    }
+
+    // MARK: - Authorization
+
+    func requestAuthorization() async throws {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            _writeAuthorizationStatus.withLock { $0 = .notAvailable }
+            throw HealthKitError.notAvailable
+        }
+
+        let typesToShare: Set<HKSampleType> = [
+            HKWorkoutType.workoutType(),
+            HKSeriesType.workoutRoute(),
+            HKQuantityType(.activeEnergyBurned),
+            HKQuantityType(.distanceWalkingRunning),
+        ]
+
+        let typesToRead: Set<HKObjectType> = [
+            HKQuantityType(.heartRate),
+            HKQuantityType(.bodyMass),
+        ]
+
+        try await healthStore.requestAuthorization(toShare: typesToShare, read: typesToRead)
+        updateAuthorizationStatusFromStore()
+    }
+
+    func refreshAuthorizationStatus() {
+        updateAuthorizationStatusFromStore()
+    }
+
+    private func updateAuthorizationStatusFromStore() {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            _writeAuthorizationStatus.withLock { $0 = .notAvailable }
+            return
+        }
+        let status = healthStore.authorizationStatus(for: HKWorkoutType.workoutType())
+        let mapped: HealthKitAuthorizationStatus = switch status {
+        case .notDetermined: .notDetermined
+        case .sharingDenied: .sharingDenied
+        case .sharingAuthorized: .sharingAuthorized
+        @unknown default: .notDetermined
+        }
+        _writeAuthorizationStatus.withLock { $0 = mapped }
+    }
+
+    // MARK: - Body Mass
+
+    func fetchLatestBodyMassKg() async -> Double? {
+        guard HKHealthStore.isHealthDataAvailable() else { return nil }
+        let bodyMassType = HKQuantityType(.bodyMass)
+        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+
+        return await withCheckedContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: bodyMassType,
+                predicate: nil,
+                limit: 1,
+                sortDescriptors: [sortDescriptor]
+            ) { _, samples, _ in
+                guard let sample = samples?.first as? HKQuantitySample else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                let kg = sample.quantity.doubleValue(for: .gramUnit(with: .kilo))
+                continuation.resume(returning: kg)
+            }
+            healthStore.execute(query)
+        }
+    }
+
+    // MARK: - Heart Rate
+
+    func fetchHeartRateSummary(start: Date, end: Date) async -> HealthKitHeartRateSummary? {
+        guard HKHealthStore.isHealthDataAvailable() else { return nil }
+        let heartRateType = HKQuantityType(.heartRate)
+        let predicate = HKQuery.predicateForSamples(withStart: start, end: end, options: .strictStartDate)
+        let bpmUnit = HKUnit.count().unitDivided(by: .minute())
+
+        return await withCheckedContinuation { continuation in
+            let query = HKStatisticsQuery(
+                quantityType: heartRateType,
+                quantitySamplePredicate: predicate,
+                options: [.discreteAverage, .discreteMax]
+            ) { _, statistics, _ in
+                let avg = statistics?.averageQuantity()?.doubleValue(for: bpmUnit)
+                let max = statistics?.maximumQuantity()?.doubleValue(for: bpmUnit)
+                guard let avg, let max else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                continuation.resume(returning: HealthKitHeartRateSummary(
+                    avgBpm: Int(avg.rounded()),
+                    maxBpm: Int(max.rounded())
+                ))
+            }
+            healthStore.execute(query)
+        }
+    }
+
+    // MARK: - Workout Write
+
+    func writeWorkout(_ workout: WorkoutWriteData, locations: [CLLocation]) async throws {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            throw HealthKitError.notAvailable
+        }
+
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .running
+        configuration.locationType = .outdoor
+
+        let builder = HKWorkoutBuilder(healthStore: healthStore, configuration: configuration, device: nil)
+
+        do {
+            try await builder.beginCollection(at: workout.startDate)
+
+            var samples: [HKSample] = []
+            let distanceQuantity = HKQuantity(unit: .meter(), doubleValue: workout.distanceMeters)
+            samples.append(HKQuantitySample(
+                type: HKQuantityType(.distanceWalkingRunning),
+                quantity: distanceQuantity,
+                start: workout.startDate,
+                end: workout.endDate
+            ))
+
+            if let calories = workout.calories, calories > 0 {
+                let energyQuantity = HKQuantity(unit: .kilocalorie(), doubleValue: Double(calories))
+                samples.append(HKQuantitySample(
+                    type: HKQuantityType(.activeEnergyBurned),
+                    quantity: energyQuantity,
+                    start: workout.startDate,
+                    end: workout.endDate
+                ))
+            }
+
+            if !samples.isEmpty {
+                try await builder.addSamples(samples)
+            }
+
+            try await builder.endCollection(at: workout.endDate)
+            let finishedWorkout = try await builder.finishWorkout()
+
+            if locations.count >= 2, let finishedWorkout {
+                let routeBuilder = HKWorkoutRouteBuilder(healthStore: healthStore, device: nil)
+                try await routeBuilder.insertRouteData(locations)
+                _ = try await routeBuilder.finishRoute(with: finishedWorkout, metadata: nil)
+            }
+        } catch {
+            logger.error("HealthKit workout write failed: \(error.localizedDescription, privacy: .public)")
+            throw HealthKitError.writeFailed(error.localizedDescription)
+        }
+    }
+}

--- a/run-jin/Services/RunSessionService.swift
+++ b/run-jin/Services/RunSessionService.swift
@@ -7,7 +7,9 @@ import os
 @Observable
 final class RunSessionService: RunSessionServiceProtocol {
     private let locationService: LocationServiceProtocol
+    private let healthKitService: HealthKitServiceProtocol
     private let modelContext: ModelContext
+    private let logger = Logger(subsystem: "app.space.k1t.run-jin", category: "RunSessionService")
 
     private(set) var state: RunSessionState = .idle
     private(set) var currentStats = RunStats()
@@ -24,15 +26,20 @@ final class RunSessionService: RunSessionServiceProtocol {
     private let statsContinuation: AsyncStream<RunStats>.Continuation
     let statsStream: AsyncStream<RunStats>
 
-    /// カロリー計算用の体重(kg) — 将来ユーザー設定から取得
-    private let userWeightKg: Double = 65.0
+    /// カロリー計算用の体重(kg)。HealthKitから取得できれば上書き、失敗時は65kgフォールバック
+    private var userWeightKg: Double = 65.0
 
     /// GPS誤差フィルタ: 速度が低すぎる or 精度が悪い点を除外
     private let minSpeed: Double = 0.5
     private let maxAccuracy: Double = 20.0
 
-    init(locationService: LocationServiceProtocol, modelContext: ModelContext) {
+    init(
+        locationService: LocationServiceProtocol,
+        healthKitService: HealthKitServiceProtocol,
+        modelContext: ModelContext
+    ) {
         self.locationService = locationService
+        self.healthKitService = healthKitService
         self.modelContext = modelContext
         let (stream, continuation) = AsyncStream<RunStats>.makeStream()
         self.statsStream = stream
@@ -43,6 +50,14 @@ final class RunSessionService: RunSessionServiceProtocol {
 
     func start() async {
         guard state == .idle else { return }
+
+        // HealthKitから最新の体重を取得（失敗時は65kgフォールバック）
+        if let bodyMass = await healthKitService.fetchLatestBodyMassKg(),
+           (20.0...300.0).contains(bodyMass) {
+            userWeightKg = bodyMass
+        } else {
+            userWeightKg = 65.0
+        }
 
         state = .running
         startTime = Date()
@@ -112,6 +127,30 @@ final class RunSessionService: RunSessionServiceProtocol {
 
         modelContext.insert(session)
         try? modelContext.save()
+
+        // HealthKit統合: ラン保存後に best-effort でHRを取得し、ワークアウトを書き込む
+        let capturedStartedAt = session.startedAt
+        let capturedDistance = session.distanceMeters
+        let capturedCalories = session.calories
+        let capturedLocations = collectedLocations
+
+        if let summary = await healthKitService.fetchHeartRateSummary(start: capturedStartedAt, end: endTime) {
+            session.avgHeartRate = summary.avgBpm
+            session.maxHeartRate = summary.maxBpm
+            try? modelContext.save()
+        }
+
+        let workoutData = WorkoutWriteData(
+            startDate: capturedStartedAt,
+            endDate: endTime,
+            distanceMeters: capturedDistance,
+            calories: capturedCalories
+        )
+        do {
+            try await healthKitService.writeWorkout(workoutData, locations: capturedLocations)
+        } catch {
+            logger.error("HealthKit workout write failed: \(error.localizedDescription, privacy: .public)")
+        }
 
         statsContinuation.finish()
 

--- a/run-jin/Views/HealthKitSettingsView.swift
+++ b/run-jin/Views/HealthKitSettingsView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+import UIKit
+
+struct HealthKitSettingsView: View {
+    private let healthKitService: HealthKitServiceProtocol
+    @State private var status: HealthKitAuthorizationStatus
+    @State private var isRequesting: Bool = false
+    @State private var errorMessage: String?
+
+    init(healthKitService: HealthKitServiceProtocol = DependencyContainer.shared.healthKitService) {
+        self.healthKitService = healthKitService
+        _status = State(initialValue: healthKitService.writeAuthorizationStatus)
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                HStack {
+                    Label("ステータス", systemImage: "heart.text.square.fill")
+                    Spacer()
+                    Text(statusLabel)
+                        .foregroundStyle(.secondary)
+                }
+            } footer: {
+                Text("ワークアウトの書き込み、心拍数と体重の読み込みに使用します。拒否してもランニングの記録は通常通り行えます。")
+            }
+
+            switch status {
+            case .notDetermined:
+                Section {
+                    Button {
+                        Task { await requestAuthorization() }
+                    } label: {
+                        HStack {
+                            Spacer()
+                            if isRequesting {
+                                ProgressView()
+                            } else {
+                                Text("ヘルスケアへのアクセスを許可")
+                            }
+                            Spacer()
+                        }
+                    }
+                    .disabled(isRequesting)
+                }
+            case .sharingDenied:
+                Section {
+                    Button {
+                        openSettings()
+                    } label: {
+                        Label("設定アプリで変更", systemImage: "gearshape.fill")
+                    }
+                } footer: {
+                    Text("ヘルスケアへのアクセスが拒否されています。設定アプリから変更できます。")
+                }
+            case .sharingAuthorized:
+                Section {
+                    Label("許可済み", systemImage: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                }
+            case .notAvailable:
+                Section {
+                    Label("このデバイスでは利用できません", systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+        .navigationTitle("ヘルスケア連携")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            healthKitService.refreshAuthorizationStatus()
+            status = healthKitService.writeAuthorizationStatus
+        }
+    }
+
+    private var statusLabel: LocalizedStringKey {
+        switch status {
+        case .notDetermined: "未設定"
+        case .sharingAuthorized: "許可済み"
+        case .sharingDenied: "拒否"
+        case .notAvailable: "利用不可"
+        }
+    }
+
+    private func requestAuthorization() async {
+        isRequesting = true
+        errorMessage = nil
+        do {
+            try await healthKitService.requestAuthorization()
+            status = healthKitService.writeAuthorizationStatus
+        } catch {
+            errorMessage = error.localizedDescription
+            status = healthKitService.writeAuthorizationStatus
+        }
+        isRequesting = false
+    }
+
+    private func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        HealthKitSettingsView()
+    }
+}

--- a/run-jin/Views/ProfileTabView.swift
+++ b/run-jin/Views/ProfileTabView.swift
@@ -148,6 +148,11 @@ struct ProfileTabView: View {
             } label: {
                 Label("匿名モード", systemImage: "eye.slash.fill")
             }
+            NavigationLink {
+                HealthKitSettingsView()
+            } label: {
+                Label("ヘルスケア連携", systemImage: "heart.fill")
+            }
         }
     }
 

--- a/run-jin/run-jin.entitlements
+++ b/run-jin/run-jin.entitlements
@@ -6,5 +6,7 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
 </dict>
 </plist>

--- a/run-jinTests/HealthKitServiceTests.swift
+++ b/run-jinTests/HealthKitServiceTests.swift
@@ -1,0 +1,133 @@
+import Testing
+import CoreLocation
+import Foundation
+@testable import run_jin
+
+/// テスト用のモックHealthKitService
+final class MockHealthKitService: HealthKitServiceProtocol, @unchecked Sendable {
+    var isHealthDataAvailable: Bool = true
+    private(set) var writeAuthorizationStatus: HealthKitAuthorizationStatus = .notDetermined
+
+    var stubBodyMassKg: Double?
+    var stubHeartRateSummary: HealthKitHeartRateSummary?
+    var shouldThrowOnRequest: Bool = false
+    var shouldThrowOnWrite: Bool = false
+
+    private(set) var requestAuthorizationCallCount: Int = 0
+    private(set) var refreshAuthorizationStatusCallCount: Int = 0
+    private(set) var writeWorkoutCallCount: Int = 0
+    private(set) var lastWrittenWorkout: WorkoutWriteData?
+    private(set) var lastWriteLocations: [CLLocation] = []
+
+    func requestAuthorization() async throws {
+        requestAuthorizationCallCount += 1
+        if shouldThrowOnRequest {
+            throw HealthKitError.notAvailable
+        }
+        writeAuthorizationStatus = .sharingAuthorized
+    }
+
+    func refreshAuthorizationStatus() {
+        refreshAuthorizationStatusCallCount += 1
+    }
+
+    func fetchLatestBodyMassKg() async -> Double? {
+        stubBodyMassKg
+    }
+
+    func fetchHeartRateSummary(start: Date, end: Date) async -> HealthKitHeartRateSummary? {
+        stubHeartRateSummary
+    }
+
+    func writeWorkout(_ workout: WorkoutWriteData, locations: [CLLocation]) async throws {
+        writeWorkoutCallCount += 1
+        lastWrittenWorkout = workout
+        lastWriteLocations = locations
+        if shouldThrowOnWrite {
+            throw HealthKitError.writeFailed("mock")
+        }
+    }
+}
+
+struct HealthKitServiceTests {
+
+    @Test func mockStartsNotDetermined() async throws {
+        let mock = MockHealthKitService()
+        #expect(mock.writeAuthorizationStatus == .notDetermined)
+    }
+
+    @Test func requestAuthorizationTransitionsToAuthorized() async throws {
+        let mock = MockHealthKitService()
+        try await mock.requestAuthorization()
+        #expect(mock.requestAuthorizationCallCount == 1)
+        #expect(mock.writeAuthorizationStatus == .sharingAuthorized)
+    }
+
+    @Test func requestAuthorizationThrowsWhenConfigured() async throws {
+        let mock = MockHealthKitService()
+        mock.shouldThrowOnRequest = true
+        await #expect(throws: HealthKitError.self) {
+            try await mock.requestAuthorization()
+        }
+    }
+
+    @Test func fetchBodyMassReturnsStubValue() async throws {
+        let mock = MockHealthKitService()
+        mock.stubBodyMassKg = 72.5
+        let result = await mock.fetchLatestBodyMassKg()
+        #expect(result == 72.5)
+    }
+
+    @Test func fetchBodyMassReturnsNilByDefault() async throws {
+        let mock = MockHealthKitService()
+        let result = await mock.fetchLatestBodyMassKg()
+        #expect(result == nil)
+    }
+
+    @Test func fetchHeartRateReturnsStubSummary() async throws {
+        let mock = MockHealthKitService()
+        mock.stubHeartRateSummary = HealthKitHeartRateSummary(avgBpm: 145, maxBpm: 172)
+        let result = await mock.fetchHeartRateSummary(start: Date(), end: Date())
+        #expect(result?.avgBpm == 145)
+        #expect(result?.maxBpm == 172)
+    }
+
+    @Test func fetchHeartRateReturnsNilByDefault() async throws {
+        let mock = MockHealthKitService()
+        let result = await mock.fetchHeartRateSummary(start: Date(), end: Date())
+        #expect(result == nil)
+    }
+
+    @Test func writeWorkoutCapturesDataAndLocations() async throws {
+        let mock = MockHealthKitService()
+        let start = Date()
+        let workout = WorkoutWriteData(
+            startDate: start,
+            endDate: start.addingTimeInterval(60),
+            distanceMeters: 200,
+            calories: 15
+        )
+        let locations = [
+            CLLocation(latitude: 35.0, longitude: 139.0),
+            CLLocation(latitude: 35.001, longitude: 139.001),
+        ]
+        try await mock.writeWorkout(workout, locations: locations)
+        #expect(mock.writeWorkoutCallCount == 1)
+        #expect(mock.lastWrittenWorkout?.distanceMeters == 200)
+        #expect(mock.lastWriteLocations.count == 2)
+    }
+
+    @Test func writeWorkoutThrowsWhenConfigured() async throws {
+        let mock = MockHealthKitService()
+        mock.shouldThrowOnWrite = true
+        let workout = WorkoutWriteData(
+            startDate: Date(),
+            endDate: Date(),
+            distanceMeters: 0,
+            calories: nil
+        )
+        await #expect(throws: HealthKitError.self) {
+            try await mock.writeWorkout(workout, locations: [])
+        }
+    }
+}

--- a/run-jinTests/RunSessionServiceTests.swift
+++ b/run-jinTests/RunSessionServiceTests.swift
@@ -58,6 +58,7 @@ struct RunSessionServiceTests {
 
         let service = RunSessionService(
             locationService: mockLocation,
+            healthKitService: MockHealthKitService(),
             modelContext: context
         )
 
@@ -84,6 +85,7 @@ struct RunSessionServiceTests {
 
         let service = RunSessionService(
             locationService: mockLocation,
+            healthKitService: MockHealthKitService(),
             modelContext: context
         )
 
@@ -101,5 +103,75 @@ struct RunSessionServiceTests {
         #expect(service.currentStats.distanceMeters == 0)
         #expect(service.currentStats.calories == 0)
         #expect(service.routeCoordinates.isEmpty)
+    }
+
+    @Test @MainActor func finishPopulatesHeartRateFromHealthKit() async throws {
+        let mockLocation = MockLocationService()
+        let mockHealthKit = MockHealthKitService()
+        mockHealthKit.stubHeartRateSummary = HealthKitHeartRateSummary(avgBpm: 140, maxBpm: 165)
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: RunSession.self, RunLocation.self,
+            configurations: config
+        )
+        let context = container.mainContext
+
+        let service = RunSessionService(
+            locationService: mockLocation,
+            healthKitService: mockHealthKit,
+            modelContext: context
+        )
+
+        await service.start()
+        let session = await service.finish()
+
+        #expect(session?.avgHeartRate == 140)
+        #expect(session?.maxHeartRate == 165)
+    }
+
+    @Test @MainActor func finishCallsWriteWorkoutExactlyOnce() async throws {
+        let mockLocation = MockLocationService()
+        let mockHealthKit = MockHealthKitService()
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: RunSession.self, RunLocation.self,
+            configurations: config
+        )
+        let context = container.mainContext
+
+        let service = RunSessionService(
+            locationService: mockLocation,
+            healthKitService: mockHealthKit,
+            modelContext: context
+        )
+
+        await service.start()
+        _ = await service.finish()
+
+        #expect(mockHealthKit.writeWorkoutCallCount == 1)
+    }
+
+    @Test @MainActor func finishSucceedsWhenHealthKitThrows() async throws {
+        let mockLocation = MockLocationService()
+        let mockHealthKit = MockHealthKitService()
+        mockHealthKit.shouldThrowOnWrite = true
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: RunSession.self, RunLocation.self,
+            configurations: config
+        )
+        let context = container.mainContext
+
+        let service = RunSessionService(
+            locationService: mockLocation,
+            healthKitService: mockHealthKit,
+            modelContext: context
+        )
+
+        await service.start()
+        let session = await service.finish()
+
+        #expect(session != nil)
+        #expect(service.state == .idle)
     }
 }

--- a/supabase/migrations/20260408000000_add_heart_rate_to_run_sessions.sql
+++ b/supabase/migrations/20260408000000_add_heart_rate_to_run_sessions.sql
@@ -1,0 +1,6 @@
+-- Add heart rate columns to run_sessions for HealthKit integration.
+-- Both columns are optional; legacy rows remain NULL.
+
+ALTER TABLE public.run_sessions
+    ADD COLUMN IF NOT EXISTS avg_heart_rate SMALLINT,
+    ADD COLUMN IF NOT EXISTS max_heart_rate SMALLINT;


### PR DESCRIPTION
ラン完了時にApple Healthへワークアウト・ルートを書き込み、心拍数と
体重をHealthKitから読み取る機能を追加。

- HealthKitService: HKWorkoutBuilder + HKWorkoutRouteBuilder で
  ワークアウトとGPSルートを書き込み、HKStatisticsQuery で平均/最大
  HRを集計、HKSampleQuery で最新体重を取得
- RunSession に avgHeartRate / maxHeartRate フィールドを追加
- RunSessionService: 体重をHealthKitから取得（失敗時は65kg
  フォールバック）し、finish() でラン保存後にHR集計とワークアウト
  書き込みを best-effort で実行
- HealthKitSettingsView: 認可状態の表示と Settings アプリへの
  ディープリンクを提供
- HealthKit entitlement と NSHealthShareUsageDescription /
  NSHealthUpdateUsageDescription を追加
- MockHealthKitService と統合テストを追加
- run_sessions テーブルに HR カラムを追加するマイグレーション

https://claude.ai/code/session_011XG4LwnTTc67sCzQ8f1T3y

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>