### PR TITLE
feat: integrate run completion → territory capture → sync flow

### DIFF
--- a/run-jin/App/DependencyContainer.swift
+++ b/run-jin/App/DependencyContainer.swift
@@ -13,6 +13,8 @@ final class DependencyContainer: @unchecked Sendable {
     private var _runSessionService: RunSessionService?
     private var _storeKitService: StoreKitServiceProtocol?
     private var _voiceFeedbackService: VoiceFeedbackServiceProtocol?
+    private var _h3Service: H3ServiceProtocol?
+    private var _territoryCaptureEngine: TerritoryCaptureEngineProtocol?
 
     var authService: any AuthServiceProtocol {
         if _authService == nil {
@@ -49,6 +51,20 @@ final class DependencyContainer: @unchecked Sendable {
         return _storeKitService!
     }
 
+    var h3Service: H3ServiceProtocol {
+        if _h3Service == nil {
+            _h3Service = H3Service()
+        }
+        return _h3Service!
+    }
+
+    var territoryCaptureEngine: TerritoryCaptureEngineProtocol {
+        if _territoryCaptureEngine == nil {
+            _territoryCaptureEngine = TerritoryCaptureEngine(h3Service: h3Service)
+        }
+        return _territoryCaptureEngine!
+    }
+
     @MainActor
     func runSessionService(modelContext: ModelContext) -> RunSessionService {
         if _runSessionService == nil {
@@ -59,6 +75,19 @@ final class DependencyContainer: @unchecked Sendable {
             )
         }
         return _runSessionService!
+    }
+
+    @MainActor
+    func runSyncService(modelContext: ModelContext) -> RunSyncService {
+        RunSyncService(modelContext: modelContext, h3Service: h3Service)
+    }
+
+    @MainActor
+    func runCompletionService(modelContext: ModelContext) -> RunCompletionService {
+        RunCompletionService(
+            captureEngine: territoryCaptureEngine,
+            modelContext: modelContext
+        )
     }
 
     private init() {

--- a/run-jin/Core/Protocols/TerritoryCaptureEngineProtocol.swift
+++ b/run-jin/Core/Protocols/TerritoryCaptureEngineProtocol.swift
@@ -7,7 +7,7 @@ struct CaptureResult: Sendable {
     let failedCells: [String]     // 上書き条件を満たさなかったH3インデックス
 }
 
-struct CellCaptureData: Sendable {
+struct CellCaptureData: Sendable, Codable {
     let h3Index: String
     let distanceMeters: Double
 }

--- a/run-jin/Models/DTO/SubmitRunDTO.swift
+++ b/run-jin/Models/DTO/SubmitRunDTO.swift
@@ -1,0 +1,104 @@
+import CoreLocation
+import Foundation
+
+// MARK: - Request
+
+struct SubmitRunCellDTO: Codable, Sendable {
+    let h3Index: String
+    let distanceMeters: Double
+    let lat: Double
+    let lng: Double
+
+    enum CodingKeys: String, CodingKey {
+        case h3Index = "h3_index"
+        case distanceMeters = "distance_meters"
+        case lat
+        case lng
+    }
+}
+
+struct SubmitRunCoordinateDTO: Codable, Sendable {
+    let lat: Double
+    let lng: Double
+}
+
+struct SubmitRunRequestDTO: Codable, Sendable {
+    let idempotencyKey: String
+    let startedAt: String
+    let endedAt: String
+    let distanceMeters: Double
+    let durationSeconds: Int
+    let avgPaceSecondsPerKm: Double?
+    let calories: Int?
+    let routeCoordinates: [SubmitRunCoordinateDTO]?
+    let cells: [SubmitRunCellDTO]
+
+    enum CodingKeys: String, CodingKey {
+        case idempotencyKey = "idempotency_key"
+        case startedAt = "started_at"
+        case endedAt = "ended_at"
+        case distanceMeters = "distance_meters"
+        case durationSeconds = "duration_seconds"
+        case avgPaceSecondsPerKm = "avg_pace_seconds_per_km"
+        case calories
+        case routeCoordinates = "route_coordinates"
+        case cells
+    }
+}
+
+extension SubmitRunRequestDTO {
+    static func from(
+        session: RunSession,
+        cells: [CellCaptureData],
+        h3Service: H3ServiceProtocol
+    ) throws -> SubmitRunRequestDTO {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let locations = session.locations.sorted { $0.timestamp < $1.timestamp }
+
+        let routeCoordinates: [SubmitRunCoordinateDTO]? = if locations.count >= 2 {
+            locations.map { SubmitRunCoordinateDTO(lat: $0.latitude, lng: $0.longitude) }
+        } else {
+            nil
+        }
+
+        let cellDTOs = try cells.map { cell in
+            let centroid = try h3Service.centroid(for: cell.h3Index)
+            return SubmitRunCellDTO(
+                h3Index: cell.h3Index,
+                distanceMeters: cell.distanceMeters,
+                lat: centroid.latitude,
+                lng: centroid.longitude
+            )
+        }
+
+        return SubmitRunRequestDTO(
+            idempotencyKey: session.idempotencyKey,
+            startedAt: formatter.string(from: session.startedAt),
+            endedAt: formatter.string(from: session.endedAt ?? Date()),
+            distanceMeters: session.distanceMeters,
+            durationSeconds: session.durationSeconds,
+            avgPaceSecondsPerKm: session.avgPaceSecondsPerKm,
+            calories: session.calories,
+            routeCoordinates: routeCoordinates,
+            cells: cellDTOs
+        )
+    }
+}
+
+// MARK: - Response
+
+struct SubmitRunResponseDTO: Codable, Sendable {
+    let sessionId: String
+    let cellsCaptured: Int
+    let cellsOverridden: Int
+    let totalCellsProcessed: Int
+
+    enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case cellsCaptured = "cells_captured"
+        case cellsOverridden = "cells_overridden"
+        case totalCellsProcessed = "total_cells_processed"
+    }
+}

--- a/run-jin/Models/Domain/RunSession.swift
+++ b/run-jin/Models/Domain/RunSession.swift
@@ -17,6 +17,9 @@ final class RunSession {
     var syncStatus: SyncStatus
     var idempotencyKey: String
 
+    /// オフラインリトライ用: JSON-encoded [CellCaptureData]
+    var cellsData: Data?
+
     @Relationship(deleteRule: .cascade, inverse: \RunLocation.session)
     var locations: [RunLocation]
 
@@ -34,6 +37,7 @@ final class RunSession {
         cellsOverridden: Int = 0,
         syncStatus: SyncStatus = .pending,
         idempotencyKey: String = UUID().uuidString,
+        cellsData: Data? = nil,
         locations: [RunLocation] = []
     ) {
         self.id = id
@@ -49,6 +53,7 @@ final class RunSession {
         self.cellsOverridden = cellsOverridden
         self.syncStatus = syncStatus
         self.idempotencyKey = idempotencyKey
+        self.cellsData = cellsData
         self.locations = locations
     }
 }

--- a/run-jin/Services/RunCompletionService.swift
+++ b/run-jin/Services/RunCompletionService.swift
@@ -1,0 +1,114 @@
+import CoreLocation
+import Foundation
+import Supabase
+import SwiftData
+
+@MainActor
+@Observable
+final class RunCompletionService {
+    private let captureEngine: TerritoryCaptureEngineProtocol
+    private let modelContext: ModelContext
+
+    private(set) var captureResult: CaptureResult?
+    private(set) var extractedCells: [CellCaptureData] = []
+    private(set) var isProcessing = false
+
+    init(
+        captureEngine: TerritoryCaptureEngineProtocol,
+        modelContext: ModelContext
+    ) {
+        self.captureEngine = captureEngine
+        self.modelContext = modelContext
+    }
+
+    /// ラン完了後にセル抽出→楽観的評価を実行
+    func processCompletedRun(_ session: RunSession) async {
+        isProcessing = true
+        defer { isProcessing = false }
+
+        let coordinates = session.locations
+            .sorted { $0.timestamp < $1.timestamp }
+            .map { CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude) }
+
+        guard coordinates.count >= 2 else {
+            captureResult = CaptureResult(capturedCells: [], overriddenCells: [], failedCells: [])
+            return
+        }
+
+        do {
+            let cells = try captureEngine.extractCells(from: coordinates)
+            extractedCells = cells
+
+            // オフラインリトライ用にセルデータをセッションに保存
+            session.cellsData = try? JSONEncoder().encode(cells)
+            try? modelContext.save()
+        } catch {
+            extractedCells = []
+            captureResult = CaptureResult(capturedCells: [], overriddenCells: [], failedCells: [])
+            return
+        }
+
+        // 楽観的評価: ローカルTerritoryデータと照合
+        // 認証エラー時は空文字列で評価（ローカル比較のみに影響）
+        let userId = (try? await currentUserId()) ?? ""
+        let descriptor = FetchDescriptor<Territory>()
+        let existingTerritories = (try? modelContext.fetch(descriptor)) ?? []
+
+        captureResult = captureEngine.evaluateCaptures(
+            cells: extractedCells,
+            currentUserId: userId,
+            existingTerritories: existingTerritories
+        )
+    }
+
+    /// サーバー確認後にローカルTerritoryモデルを更新
+    func saveTerritoriesLocally(ownerId: String) {
+        guard let result = captureResult else { return }
+
+        let cellDistanceMap = Dictionary(
+            uniqueKeysWithValues: extractedCells.map { ($0.h3Index, $0.distanceMeters) }
+        )
+
+        for h3Index in result.capturedCells {
+            let territory = Territory(
+                h3Index: h3Index,
+                ownerId: ownerId,
+                totalDistanceMeters: cellDistanceMap[h3Index] ?? 0
+            )
+            modelContext.insert(territory)
+        }
+
+        for h3Index in result.overriddenCells {
+            let targetIndex = h3Index
+            let descriptor = FetchDescriptor<Territory>(
+                predicate: #Predicate { $0.h3Index == targetIndex }
+            )
+            if let existing = try? modelContext.fetch(descriptor).first {
+                existing.ownerId = ownerId
+                existing.capturedAt = Date()
+                existing.totalDistanceMeters = cellDistanceMap[h3Index] ?? 0
+            } else {
+                let territory = Territory(
+                    h3Index: h3Index,
+                    ownerId: ownerId,
+                    totalDistanceMeters: cellDistanceMap[h3Index] ?? 0
+                )
+                modelContext.insert(territory)
+            }
+        }
+
+        try? modelContext.save()
+    }
+
+    func reset() {
+        captureResult = nil
+        extractedCells = []
+    }
+
+    // MARK: - Private
+
+    private func currentUserId() async throws -> String {
+        let session = try await supabase.auth.session
+        return session.user.id.uuidString
+    }
+}

--- a/run-jin/Services/RunSyncService.swift
+++ b/run-jin/Services/RunSyncService.swift
@@ -7,29 +7,60 @@ import Network
 @Observable
 final class RunSyncService: RunSyncServiceProtocol {
     private let modelContext: ModelContext
+    private let h3Service: H3ServiceProtocol
     private let monitor = NWPathMonitor()
     private var isConnected = true
 
-    init(modelContext: ModelContext) {
+    init(modelContext: ModelContext, h3Service: H3ServiceProtocol) {
         self.modelContext = modelContext
+        self.h3Service = h3Service
         startNetworkMonitoring()
     }
 
-    /// ラン完了時にアップロード。オフラインの場合はpendingのまま
+    /// Edge Function経由でラン+セルデータを送信
+    func submitRun(
+        session: RunSession,
+        cells: [CellCaptureData]
+    ) async throws -> SubmitRunResponseDTO {
+        let requestDTO = try SubmitRunRequestDTO.from(
+            session: session,
+            cells: cells,
+            h3Service: h3Service
+        )
+
+        let responseDTO: SubmitRunResponseDTO = try await supabase.functions.invoke(
+            "submit-run",
+            options: .init(body: requestDTO)
+        )
+
+        session.cellsCaptured = responseDTO.cellsCaptured
+        session.cellsOverridden = responseDTO.cellsOverridden
+        session.syncStatus = .synced
+        try? modelContext.save()
+
+        return responseDTO
+    }
+
+    /// ラン完了時にアップロード。セルデータがあればEdge Function、なければ直接upsert
     func uploadSession(_ session: RunSession) async throws {
         guard isConnected else { return }
         guard session.syncStatus == .pending else { return }
 
-        let userId = try await currentUserId()
-        let dto = RunSessionDTO.from(session: session, userId: userId)
+        if let cellsData = session.cellsData,
+           let cells = try? JSONDecoder().decode([CellCaptureData].self, from: cellsData) {
+            _ = try await submitRun(session: session, cells: cells)
+        } else {
+            let userId = try await currentUserId()
+            let dto = RunSessionDTO.from(session: session, userId: userId)
 
-        try await supabase
-            .from("run_sessions")
-            .upsert(dto, onConflict: "idempotency_key")
-            .execute()
+            try await supabase
+                .from("run_sessions")
+                .upsert(dto, onConflict: "idempotency_key")
+                .execute()
 
-        session.syncStatus = .synced
-        try? modelContext.save()
+            session.syncStatus = .synced
+            try? modelContext.save()
+        }
     }
 
     /// 未同期セッションを一括アップロード

--- a/run-jin/ViewModels/RunningViewModel.swift
+++ b/run-jin/ViewModels/RunningViewModel.swift
@@ -8,12 +8,20 @@ import SwiftUI
 final class RunningViewModel {
     let runSessionService: RunSessionService
     let voiceFeedbackService: VoiceFeedbackServiceProtocol
+    let runCompletionService: RunCompletionService
+    let runSyncService: RunSyncService
 
     var state: RunSessionState { runSessionService.state }
     var stats: RunStats { runSessionService.currentStats }
     var routeCoordinates: [CLLocationCoordinate2D] { runSessionService.routeCoordinates }
 
     var cameraPosition: MapCameraPosition = .userLocation(fallback: .automatic)
+
+    // MARK: - Territory Reveal
+
+    var showTerritoryReveal = false
+    var captureResult: CaptureResult? { runCompletionService.captureResult }
+    private(set) var completedSession: RunSession?
 
     // MARK: - Screen Lock
 
@@ -24,10 +32,14 @@ final class RunningViewModel {
 
     init(
         runSessionService: RunSessionService,
-        voiceFeedbackService: VoiceFeedbackServiceProtocol
+        voiceFeedbackService: VoiceFeedbackServiceProtocol,
+        runCompletionService: RunCompletionService,
+        runSyncService: RunSyncService
     ) {
         self.runSessionService = runSessionService
         self.voiceFeedbackService = voiceFeedbackService
+        self.runCompletionService = runCompletionService
+        self.runSyncService = runSyncService
     }
 
     func startRun() async {
@@ -43,9 +55,29 @@ final class RunningViewModel {
         await runSessionService.resume()
     }
 
-    func finishRun() async -> RunSession? {
+    func finishRun() async {
         unlockScreen()
-        return await runSessionService.finish()
+        guard let session = await runSessionService.finish() else { return }
+
+        completedSession = session
+        await runCompletionService.processCompletedRun(session)
+
+        if let result = captureResult,
+           !result.capturedCells.isEmpty || !result.overriddenCells.isEmpty {
+            showTerritoryReveal = true
+        } else {
+            // セルなし: リビールをスキップして直接同期
+            await submitInBackground(session: session)
+        }
+    }
+
+    func onRevealDismissed() {
+        guard let session = completedSession else { return }
+        Task {
+            await submitInBackground(session: session)
+        }
+        runCompletionService.reset()
+        completedSession = nil
     }
 
     // MARK: - Screen Lock
@@ -91,5 +123,16 @@ final class RunningViewModel {
 
     var formattedCalories: String {
         FormatHelpers.calories(stats.calories)
+    }
+
+    // MARK: - Private
+
+    private func submitInBackground(session: RunSession) async {
+        let cells = runCompletionService.extractedCells
+        do {
+            _ = try await runSyncService.submitRun(session: session, cells: cells)
+        } catch {
+            // オフライン時はpendingのまま、次回ネットワーク復帰時にリトライ
+        }
     }
 }

--- a/run-jin/Views/RunningTabView.swift
+++ b/run-jin/Views/RunningTabView.swift
@@ -21,9 +21,13 @@ struct RunningTabView: View {
         .onAppear {
             if viewModel == nil {
                 let service = container.runSessionService(modelContext: modelContext)
+                let completionService = container.runCompletionService(modelContext: modelContext)
+                let syncService = container.runSyncService(modelContext: modelContext)
                 viewModel = RunningViewModel(
                     runSessionService: service,
-                    voiceFeedbackService: container.voiceFeedbackService
+                    voiceFeedbackService: container.voiceFeedbackService,
+                    runCompletionService: completionService,
+                    runSyncService: syncService
                 )
             }
         }
@@ -74,10 +78,24 @@ struct RunningTabView: View {
         ) {
             Button("終了する", role: .destructive) {
                 Task {
-                    let _ = await viewModel.finishRun()
+                    await viewModel.finishRun()
                 }
             }
             Button("キャンセル", role: .cancel) {}
+        }
+        .fullScreenCover(
+            isPresented: Binding(
+                get: { viewModel.showTerritoryReveal },
+                set: { viewModel.showTerritoryReveal = $0 }
+            )
+        ) {
+            viewModel.onRevealDismissed()
+        } content: {
+            if let captureResult = viewModel.captureResult {
+                NavigationStack {
+                    TerritoryRevealView(captureResult: captureResult)
+                }
+            }
         }
         .onChange(of: viewModel.stats.distanceMeters) {
             viewModel.checkKilometerMilestone()


### PR DESCRIPTION
## Summary
- ラン完了時にGPS座標からH3セルを抽出し、ローカルTerritoryと楽観的評価
- `TerritoryRevealView` を `fullScreenCover` で表示し、獲得ヘックスをアニメーション
- リビュー閉鎖後に `submit-run` Edge Function にセルデータ付きで送信
- オフラインリトライ用に `RunSession.cellsData` を追加

### 新規ファイル
- `run-jin/Models/DTO/SubmitRunDTO.swift` — Edge Function用DTO
- `run-jin/Services/RunCompletionService.swift` — ラン完了オーケストレーション

### 修正ファイル
- `RunSyncService` — `submit-run` Edge Function呼び出しに変更
- `RunningViewModel` — セル抽出→リビール→同期フロー
- `RunningTabView` — `fullScreenCover` 追加
- `DependencyContainer` — 新サービス登録
- `CellCaptureData` に `Codable` 追加 / `RunSession.cellsData` 追加

## Test Plan
- [x] `make build` 成功
- [x] `make test` 全テスト通過
- [x] シミュレーター + `simctl location start` で実走シミュレート
- [x] 東京駅→日本橋方面の経路で「テリトリー獲得」画面に5つの新規ヘックスが表示されることを確認
- [x] 閉じるボタンでラン画面に正常復帰

## 実装中の発見
`RunCompletionService` で `currentUserId()` の throw が `extractCells` と同じ do-catch 節にあったため、認証エラー時に `captureResult` が空になりリビューがスキップされる不具合を発見・修正。認証失敗時は空文字列userIdで評価を継続するように分離した。

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)