### PR TITLE
fix: run reliability bundle — BG GPS, privacy zone, sync retry

### DIFF
--- a/run-jin/App/DependencyContainer.swift
+++ b/run-jin/App/DependencyContainer.swift
@@ -15,6 +15,7 @@ final class DependencyContainer: @unchecked Sendable {
     private var _voiceFeedbackService: VoiceFeedbackServiceProtocol?
     private var _h3Service: H3ServiceProtocol?
     private var _territoryCaptureEngine: TerritoryCaptureEngineProtocol?
+    private var _runSyncService: RunSyncService?
 
     var authService: any AuthServiceProtocol {
         if _authService == nil {
@@ -79,7 +80,10 @@ final class DependencyContainer: @unchecked Sendable {
 
     @MainActor
     func runSyncService(modelContext: ModelContext) -> RunSyncService {
-        RunSyncService(modelContext: modelContext, h3Service: h3Service)
+        if _runSyncService == nil {
+            _runSyncService = RunSyncService(modelContext: modelContext, h3Service: h3Service)
+        }
+        return _runSyncService!
     }
 
     @MainActor

--- a/run-jin/Core/Protocols/RunSyncServiceProtocol.swift
+++ b/run-jin/Core/Protocols/RunSyncServiceProtocol.swift
@@ -2,5 +2,6 @@ import Foundation
 
 protocol RunSyncServiceProtocol: Sendable {
     func uploadSession(_ session: RunSession) async throws
+    func submitCompletedRun(session: RunSession, cells: [CellCaptureData]) async
     func syncPendingSessions() async
 }

--- a/run-jin/Models/Domain/RunSession.swift
+++ b/run-jin/Models/Domain/RunSession.swift
@@ -16,6 +16,8 @@ final class RunSession {
     var cellsOverridden: Int
     var syncStatus: SyncStatus
     var idempotencyKey: String
+    var lastSyncError: String?
+    var syncRetryCount: Int
 
     /// オフラインリトライ用: JSON-encoded [CellCaptureData]
     var cellsData: Data?
@@ -37,6 +39,8 @@ final class RunSession {
         cellsOverridden: Int = 0,
         syncStatus: SyncStatus = .pending,
         idempotencyKey: String = UUID().uuidString,
+        lastSyncError: String? = nil,
+        syncRetryCount: Int = 0,
         cellsData: Data? = nil,
         locations: [RunLocation] = []
     ) {
@@ -53,6 +57,8 @@ final class RunSession {
         self.cellsOverridden = cellsOverridden
         self.syncStatus = syncStatus
         self.idempotencyKey = idempotencyKey
+        self.lastSyncError = lastSyncError
+        self.syncRetryCount = syncRetryCount
         self.cellsData = cellsData
         self.locations = locations
     }
@@ -62,4 +68,5 @@ enum SyncStatus: String, Codable {
     case pending
     case synced
     case conflict
+    case failed
 }

--- a/run-jin/Services/LocationService.swift
+++ b/run-jin/Services/LocationService.swift
@@ -29,6 +29,8 @@ final class LocationService: NSObject, LocationServiceProtocol, CLLocationManage
         manager.desiredAccuracy = kCLLocationAccuracyBest
         manager.distanceFilter = 5.0
         manager.pausesLocationUpdatesAutomatically = false
+        manager.activityType = .fitness
+        manager.showsBackgroundLocationIndicator = true
 
         updateAuthorizationStatus(manager.authorizationStatus)
     }
@@ -48,11 +50,18 @@ final class LocationService: NSObject, LocationServiceProtocol, CLLocationManage
     }
 
     func startUpdating() {
+        // allowsBackgroundLocationUpdates は authorization が付与されている時のみ有効化する。
+        // notDetermined/denied で true にすると CLLocationManager が警告を出す。
+        if manager.authorizationStatus == .authorizedAlways ||
+           manager.authorizationStatus == .authorizedWhenInUse {
+            manager.allowsBackgroundLocationUpdates = true
+        }
         manager.startUpdatingLocation()
     }
 
     func stopUpdating() {
         manager.stopUpdatingLocation()
+        manager.allowsBackgroundLocationUpdates = false
     }
 
     // MARK: - CLLocationManagerDelegate

--- a/run-jin/Services/RunSessionService.swift
+++ b/run-jin/Services/RunSessionService.swift
@@ -17,6 +17,7 @@ final class RunSessionService: RunSessionServiceProtocol {
     private var session: RunSession?
     private(set) var routeCoordinates: [CLLocationCoordinate2D] = []
     private var collectedLocations: [CLLocation] = []
+    private var activePrivacyZones: [PrivacyZone] = []
     private var locationTask: Task<Void, Never>?
     private var timerTask: Task<Void, Never>?
     private var startTime: Date?
@@ -51,6 +52,11 @@ final class RunSessionService: RunSessionServiceProtocol {
     func start() async {
         guard state == .idle else { return }
 
+        // 画面ロック中もルートを追跡するため Always 認可に昇格を要求
+        if locationService.authorizationStatus == .authorizedWhenInUse {
+            locationService.requestAlwaysAuthorization()
+        }
+
         // HealthKitから最新の体重を取得（失敗時は65kgフォールバック）
         if let bodyMass = await healthKitService.fetchLatestBodyMassKg(),
            (20.0...300.0).contains(bodyMass) {
@@ -67,6 +73,11 @@ final class RunSessionService: RunSessionServiceProtocol {
         currentStats = RunStats()
 
         session = RunSession(startedAt: startTime!)
+
+        // Privacy zone は session 開始時に snapshot し、pause/resume 中の変更は意図的に反映しない。
+        // ラン中に zone を編集しても記録済み座標の扱いが変わらず、挙動が予測しやすいため。
+        let zoneDescriptor = FetchDescriptor<PrivacyZone>()
+        activePrivacyZones = (try? modelContext.fetch(zoneDescriptor)) ?? []
 
         locationService.startUpdating()
         startListeningToLocations()
@@ -160,6 +171,7 @@ final class RunSessionService: RunSessionServiceProtocol {
         currentStats = RunStats()
         routeCoordinates = []
         collectedLocations = []
+        activePrivacyZones = []
         pausedDuration = 0
         startTime = nil
 
@@ -181,6 +193,11 @@ final class RunSessionService: RunSessionServiceProtocol {
     private func processLocation(_ location: CLLocation) {
         guard location.horizontalAccuracy <= maxAccuracy,
               location.speed >= minSpeed else {
+            return
+        }
+
+        // Privacy zone 内の座標は軌跡・距離・統計から完全に除外
+        if isInsidePrivacyZone(location) {
             return
         }
 
@@ -233,5 +250,15 @@ final class RunSessionService: RunSessionServiceProtocol {
         // カロリー = MET × 体重(kg) × 時間(h)
         let hours = Double(currentStats.durationSeconds) / 3600.0
         currentStats.calories = Int(10.0 * userWeightKg * hours)
+    }
+
+    private func isInsidePrivacyZone(_ location: CLLocation) -> Bool {
+        for zone in activePrivacyZones {
+            let center = CLLocation(latitude: zone.centerLatitude, longitude: zone.centerLongitude)
+            if location.distance(from: center) <= Double(zone.radiusMeters) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/run-jin/Services/RunSyncService.swift
+++ b/run-jin/Services/RunSyncService.swift
@@ -2,6 +2,7 @@ import Foundation
 import SwiftData
 import Supabase
 import Network
+import os
 
 @MainActor
 @Observable
@@ -10,6 +11,11 @@ final class RunSyncService: RunSyncServiceProtocol {
     private let h3Service: H3ServiceProtocol
     private let monitor = NWPathMonitor()
     private var isConnected = true
+    private var isSyncing = false
+    private let logger = Logger(subsystem: "app.space.k1t.run-jin", category: "RunSyncService")
+
+    /// `.failed` でも自動リトライする上限。超えたら手動リトライ待ち
+    private let maxAutoRetryCount: Int = 5
 
     init(modelContext: ModelContext, h3Service: H3ServiceProtocol) {
         self.modelContext = modelContext
@@ -36,15 +42,28 @@ final class RunSyncService: RunSyncServiceProtocol {
         session.cellsCaptured = responseDTO.cellsCaptured
         session.cellsOverridden = responseDTO.cellsOverridden
         session.syncStatus = .synced
+        session.lastSyncError = nil
+        session.syncRetryCount = 0
         try? modelContext.save()
 
         return responseDTO
     }
 
+    /// ラン完了直後のアップロード。失敗時も `.failed` 状態に遷移させて観測可能にする。
+    /// `RunningViewModel.submitInBackground` から利用。
+    func submitCompletedRun(session: RunSession, cells: [CellCaptureData]) async {
+        do {
+            _ = try await submitRun(session: session, cells: cells)
+            logger.info("Initial sync succeeded for session \(session.id.uuidString, privacy: .public)")
+        } catch {
+            recordSyncFailure(session: session, error: error)
+        }
+    }
+
     /// ラン完了時にアップロード。セルデータがあればEdge Function、なければ直接upsert
     func uploadSession(_ session: RunSession) async throws {
         guard isConnected else { return }
-        guard session.syncStatus == .pending else { return }
+        guard session.syncStatus == .pending || session.syncStatus == .failed else { return }
 
         if let cellsData = session.cellsData,
            let cells = try? JSONDecoder().decode([CellCaptureData].self, from: cellsData) {
@@ -59,31 +78,57 @@ final class RunSyncService: RunSyncServiceProtocol {
                 .execute()
 
             session.syncStatus = .synced
+            session.lastSyncError = nil
+            session.syncRetryCount = 0
             try? modelContext.save()
         }
     }
 
-    /// 未同期セッションを一括アップロード
+    /// 未同期セッションを一括アップロード。`NWPathMonitor` とアプリ起動時の 2 経路から呼ばれうるため
+    /// 再入ガードで並行実行を防ぐ（未防止だと `syncRetryCount` が重複加算される恐れがある）。
     func syncPendingSessions() async {
         guard isConnected else { return }
+        guard !isSyncing else { return }
+        isSyncing = true
+        defer { isSyncing = false }
 
         let pendingStatus = SyncStatus.pending
+        let failedStatus = SyncStatus.failed
+        let retryLimit = maxAutoRetryCount
         let descriptor = FetchDescriptor<RunSession>(
-            predicate: #Predicate { $0.syncStatus == pendingStatus }
+            predicate: #Predicate {
+                $0.syncStatus == pendingStatus ||
+                ($0.syncStatus == failedStatus && $0.syncRetryCount < retryLimit)
+            }
         )
 
-        guard let pendingSessions = try? modelContext.fetch(descriptor) else { return }
+        guard let targets = try? modelContext.fetch(descriptor) else {
+            logger.error("Failed to fetch pending sessions for sync")
+            return
+        }
 
-        for session in pendingSessions {
+        guard !targets.isEmpty else { return }
+        logger.info("Starting sync for \(targets.count, privacy: .public) sessions")
+
+        for session in targets {
             do {
                 try await uploadSession(session)
+                logger.info("Sync succeeded for session \(session.id.uuidString, privacy: .public)")
             } catch {
-                // 個別の失敗は次回の同期で再試行
+                recordSyncFailure(session: session, error: error)
             }
         }
     }
 
     // MARK: - Private
+
+    private func recordSyncFailure(session: RunSession, error: Error) {
+        session.syncStatus = .failed
+        session.syncRetryCount += 1
+        session.lastSyncError = error.localizedDescription
+        try? modelContext.save()
+        logger.error("Sync failed for session \(session.id.uuidString, privacy: .public) (attempt \(session.syncRetryCount, privacy: .public)): \(error.localizedDescription, privacy: .public)")
+    }
 
     private func currentUserId() async throws -> UUID {
         let session = try await supabase.auth.session

--- a/run-jin/ViewModels/RunningViewModel.swift
+++ b/run-jin/ViewModels/RunningViewModel.swift
@@ -128,11 +128,9 @@ final class RunningViewModel {
     // MARK: - Private
 
     private func submitInBackground(session: RunSession) async {
+        // エラー時は `RunSyncService` 側で `.failed` 状態 + Logger 出力される。
+        // NWPathMonitor / 起動時 hook がこの session を自動リトライする。
         let cells = runCompletionService.extractedCells
-        do {
-            _ = try await runSyncService.submitRun(session: session, cells: cells)
-        } catch {
-            // オフライン時はpendingのまま、次回ネットワーク復帰時にリトライ
-        }
+        await runSyncService.submitCompletedRun(session: session, cells: cells)
     }
 }

--- a/run-jin/Views/TabBarView.swift
+++ b/run-jin/Views/TabBarView.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 enum Tab: String, CaseIterable {
@@ -8,6 +9,7 @@ enum Tab: String, CaseIterable {
 }
 
 struct TabBarView: View {
+    @Environment(\.modelContext) private var modelContext
     @State private var selectedTab: Tab = .map
 
     var body: some View {
@@ -19,6 +21,10 @@ struct TabBarView: View {
                     }
                     .tag(tab)
             }
+        }
+        .task {
+            let sync = DependencyContainer.shared.runSyncService(modelContext: modelContext)
+            await sync.syncPendingSessions()
         }
     }
 

--- a/run-jinTests/RunSessionServiceTests.swift
+++ b/run-jinTests/RunSessionServiceTests.swift
@@ -174,4 +174,60 @@ struct RunSessionServiceTests {
         #expect(session != nil)
         #expect(service.state == .idle)
     }
+
+    @Test @MainActor func privacyZoneLocationsAreExcludedFromSession() async throws {
+        let mockLocation = MockLocationService()
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try ModelContainer(
+            for: RunSession.self, RunLocation.self, PrivacyZone.self,
+            configurations: config
+        )
+        let context = container.mainContext
+
+        // 自宅相当のプライバシーゾーン (半径 100m)
+        let home = PrivacyZone(
+            label: "home",
+            centerLatitude: 35.6586,
+            centerLongitude: 139.7454,
+            radiusMeters: 100
+        )
+        context.insert(home)
+        try context.save()
+
+        let service = RunSessionService(
+            locationService: mockLocation,
+            healthKitService: MockHealthKitService(),
+            modelContext: context
+        )
+
+        await service.start()
+
+        // ゾーン内座標 (中心から ~5m)
+        mockLocation.sendLocation(CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 35.65864, longitude: 139.74545),
+            altitude: 0,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            course: 0,
+            speed: 3.0,
+            timestamp: Date()
+        ))
+        // ゾーン外座標 (~1km 離れた点)
+        mockLocation.sendLocation(CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 35.6676, longitude: 139.7454),
+            altitude: 0,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            course: 0,
+            speed: 3.0,
+            timestamp: Date().addingTimeInterval(5)
+        ))
+
+        try await Task.sleep(for: .milliseconds(200))
+
+        let session = await service.finish()
+
+        #expect(session?.locations.count == 1)
+        #expect(session?.locations.first?.latitude == 35.6676)
+    }
 }


### PR DESCRIPTION
## Summary

Run 系コア機能の信頼性を上げる 4 件のバグ修正をバンドル。

- **#100 RunSyncService 起動時呼び出し** — `TabBarView.task` で `syncPendingSessions()` を起動時に 1 回走らせ、`DependencyContainer` で `_runSyncService` を lazy cache 化（毎回 `NWPathMonitor` が再生成される潜在的リークも解消）
- **#101 バックグラウンド GPS** — `activityType = .fitness`, `showsBackgroundLocationIndicator = true` を `LocationService.init` で、`allowsBackgroundLocationUpdates` は `startUpdating/stopUpdating` 内で authorization に応じて動的 set。`RunSessionService.start()` で WhenInUse→Always 昇格を要求
- **#103 同期失敗のサイレント化解消** — `os.Logger` 追加、`SyncStatus.failed` ケース / `lastSyncError` / `syncRetryCount` 追加、最大 5 回の自動リトライ、`syncPendingSessions()` 再入ガード。`RunningViewModel.submitInBackground` の初回失敗も共通 `recordSyncFailure` helper に経路統一
- **#107 プライバシーゾーンフィルタ** — `RunSessionService.start()` で `PrivacyZone` を SwiftData から snapshot し、`processLocation()` でゾーン内座標を距離・ルート・統計の加算前に除外。SwiftData/Supabase いずれにも到達しない

## Test Plan

- [x] `make build` — 警告ゼロ追加 ✅
- [x] `make test` — 全 29 ケース pass（新規 `privacyZoneLocationsAreExcludedFromSession` 含む） ✅
- [ ] 実機: Always 認可で画面ロック → 1 分以上ランし経路が途切れないこと
- [ ] 実機: 機内モード→ラン完了→復帰後に再起動→数秒で Supabase `run_sessions` にレコード到達
- [ ] Console.app で `subsystem:app.space.k1t.run-jin category:RunSyncService` の成功/失敗ログ出力
- [ ] 自宅 PrivacyZone を登録→自宅周辺でラン→ `RunHistoryView` と Supabase `run_sessions.route` に自宅座標が含まれない

## Follow-ups (out of scope)

- H3 resampler がゾーンを跨ぐ 2 点間でゾーン内セルを capture する可能性（GPS 点フィルタ単体では territory レベルの遮断を保証しない）
- `RunSessionService.pause()` が `stopUpdating()` を呼ばず、pause 中も GPS が回り続ける（バッテリー関連）
- `.failed` セッションの UI バッジ表示と手動リトライ導線
- `RunSyncService` の unit test（Supabase client 抽象化が必要）

Closes #100
Closes #101
Closes #103
Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)