### PR TITLE
test: add RunSyncService + StoreKit tests (partial #108)

### DIFF
--- a/run-jin/App/DependencyContainer.swift
+++ b/run-jin/App/DependencyContainer.swift
@@ -81,7 +81,11 @@ final class DependencyContainer: @unchecked Sendable {
     @MainActor
     func runSyncService(modelContext: ModelContext) -> RunSyncService {
         if _runSyncService == nil {
-            _runSyncService = RunSyncService(modelContext: modelContext, h3Service: h3Service)
+            _runSyncService = RunSyncService(
+                modelContext: modelContext,
+                h3Service: h3Service,
+                backend: SupabaseRunSyncBackend()
+            )
         }
         return _runSyncService!
     }

--- a/run-jin/Core/Protocols/RunSyncBackendProtocol.swift
+++ b/run-jin/Core/Protocols/RunSyncBackendProtocol.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// `RunSyncService` が Supabase に対して行う通信を抽象化するプロトコル。
+/// 本番は `SupabaseRunSyncBackend`、テストは `MockRunSyncBackend` を注入する。
+protocol RunSyncBackendProtocol: Sendable {
+    /// `submit-run` Edge Function を呼び出しセル情報付きでランをアップロード
+    func invokeSubmitRun(_ request: SubmitRunRequestDTO) async throws -> SubmitRunResponseDTO
+
+    /// `run_sessions` テーブルへ直接 upsert（セル無しランの場合）
+    func upsertRunSession(_ dto: RunSessionDTO) async throws
+
+    /// 認証済みの Supabase ユーザー ID を取得
+    func currentUserId() async throws -> UUID
+}

--- a/run-jin/Services/RunSyncService.swift
+++ b/run-jin/Services/RunSyncService.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SwiftData
-import Supabase
 import Network
 import os
 
@@ -9,6 +8,7 @@ import os
 final class RunSyncService: RunSyncServiceProtocol {
     private let modelContext: ModelContext
     private let h3Service: H3ServiceProtocol
+    private let backend: RunSyncBackendProtocol
     private let monitor = NWPathMonitor()
     private var isConnected = true
     private var isSyncing = false
@@ -17,10 +17,18 @@ final class RunSyncService: RunSyncServiceProtocol {
     /// `.failed` でも自動リトライする上限。超えたら手動リトライ待ち
     private let maxAutoRetryCount: Int = 5
 
-    init(modelContext: ModelContext, h3Service: H3ServiceProtocol) {
+    init(
+        modelContext: ModelContext,
+        h3Service: H3ServiceProtocol,
+        backend: RunSyncBackendProtocol,
+        startsNetworkMonitor: Bool = true
+    ) {
         self.modelContext = modelContext
         self.h3Service = h3Service
-        startNetworkMonitoring()
+        self.backend = backend
+        if startsNetworkMonitor {
+            startNetworkMonitoring()
+        }
     }
 
     /// Edge Function経由でラン+セルデータを送信
@@ -34,10 +42,7 @@ final class RunSyncService: RunSyncServiceProtocol {
             h3Service: h3Service
         )
 
-        let responseDTO: SubmitRunResponseDTO = try await supabase.functions.invoke(
-            "submit-run",
-            options: .init(body: requestDTO)
-        )
+        let responseDTO = try await backend.invokeSubmitRun(requestDTO)
 
         session.cellsCaptured = responseDTO.cellsCaptured
         session.cellsOverridden = responseDTO.cellsOverridden
@@ -69,13 +74,10 @@ final class RunSyncService: RunSyncServiceProtocol {
            let cells = try? JSONDecoder().decode([CellCaptureData].self, from: cellsData) {
             _ = try await submitRun(session: session, cells: cells)
         } else {
-            let userId = try await currentUserId()
+            let userId = try await backend.currentUserId()
             let dto = RunSessionDTO.from(session: session, userId: userId)
 
-            try await supabase
-                .from("run_sessions")
-                .upsert(dto, onConflict: "idempotency_key")
-                .execute()
+            try await backend.upsertRunSession(dto)
 
             session.syncStatus = .synced
             session.lastSyncError = nil
@@ -92,21 +94,18 @@ final class RunSyncService: RunSyncServiceProtocol {
         isSyncing = true
         defer { isSyncing = false }
 
-        let pendingStatus = SyncStatus.pending
-        let failedStatus = SyncStatus.failed
+        // `#Predicate` は `String` rawValue enum の直接比較をサポートしないため
+        // `syncRetryCount` のみ SwiftData 側で絞り込み、status は Swift 側でフィルタ。
         let retryLimit = maxAutoRetryCount
         let descriptor = FetchDescriptor<RunSession>(
-            predicate: #Predicate {
-                $0.syncStatus == pendingStatus ||
-                ($0.syncStatus == failedStatus && $0.syncRetryCount < retryLimit)
-            }
+            predicate: #Predicate { $0.syncRetryCount < retryLimit }
         )
-
-        guard let targets = try? modelContext.fetch(descriptor) else {
+        guard let candidates = try? modelContext.fetch(descriptor) else {
             logger.error("Failed to fetch pending sessions for sync")
             return
         }
 
+        let targets = candidates.filter { $0.syncStatus == .pending || $0.syncStatus == .failed }
         guard !targets.isEmpty else { return }
         logger.info("Starting sync for \(targets.count, privacy: .public) sessions")
 
@@ -128,11 +127,6 @@ final class RunSyncService: RunSyncServiceProtocol {
         session.lastSyncError = error.localizedDescription
         try? modelContext.save()
         logger.error("Sync failed for session \(session.id.uuidString, privacy: .public) (attempt \(session.syncRetryCount, privacy: .public)): \(error.localizedDescription, privacy: .public)")
-    }
-
-    private func currentUserId() async throws -> UUID {
-        let session = try await supabase.auth.session
-        return session.user.id
     }
 
     private func startNetworkMonitoring() {

--- a/run-jin/Services/SupabaseRunSyncBackend.swift
+++ b/run-jin/Services/SupabaseRunSyncBackend.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Supabase
+
+/// 本番向け `RunSyncBackendProtocol` 実装。グローバル `supabase` クライアントを利用。
+final class SupabaseRunSyncBackend: RunSyncBackendProtocol {
+    func invokeSubmitRun(_ request: SubmitRunRequestDTO) async throws -> SubmitRunResponseDTO {
+        try await supabase.functions.invoke(
+            "submit-run",
+            options: .init(body: request)
+        )
+    }
+
+    func upsertRunSession(_ dto: RunSessionDTO) async throws {
+        try await supabase
+            .from("run_sessions")
+            .upsert(dto, onConflict: "idempotency_key")
+            .execute()
+    }
+
+    func currentUserId() async throws -> UUID {
+        try await supabase.auth.session.user.id
+    }
+}

--- a/run-jinTests/RunSyncServiceTests.swift
+++ b/run-jinTests/RunSyncServiceTests.swift
@@ -1,0 +1,317 @@
+import Testing
+import Foundation
+import CoreLocation
+import SwiftData
+@testable import run_jin
+
+/// テスト用 `RunSyncBackend` モック。各メソッドでエラー注入・呼び出し記録ができる
+final class MockRunSyncBackend: RunSyncBackendProtocol, @unchecked Sendable {
+    var invokeSubmitRunError: Error?
+    var invokeSubmitRunResponse = SubmitRunResponseDTO(
+        sessionId: UUID().uuidString,
+        cellsCaptured: 0,
+        cellsOverridden: 0,
+        totalCellsProcessed: 0
+    )
+    private(set) var invokeSubmitRunCalls: [SubmitRunRequestDTO] = []
+
+    var upsertError: Error?
+    private(set) var upsertCalls: [RunSessionDTO] = []
+
+    var currentUserIdError: Error?
+    var currentUserIdValue: UUID = UUID()
+
+    func invokeSubmitRun(_ request: SubmitRunRequestDTO) async throws -> SubmitRunResponseDTO {
+        invokeSubmitRunCalls.append(request)
+        if let error = invokeSubmitRunError { throw error }
+        return invokeSubmitRunResponse
+    }
+
+    func upsertRunSession(_ dto: RunSessionDTO) async throws {
+        upsertCalls.append(dto)
+        if let error = upsertError { throw error }
+    }
+
+    func currentUserId() async throws -> UUID {
+        if let error = currentUserIdError { throw error }
+        return currentUserIdValue
+    }
+}
+
+/// テスト用 `H3ServiceProtocol` モック。RunSyncService が実際に呼ぶのは `centroid` のみ。
+/// その他メソッドは「呼ばれたら即失敗」で silent bug を防ぐ。
+final class MockH3Service: H3ServiceProtocol, @unchecked Sendable {
+    func h3Index(for coordinate: CLLocationCoordinate2D) throws -> String {
+        Issue.record("MockH3Service.h3Index called unexpectedly")
+        return "unused"
+    }
+
+    func boundary(for h3Index: String) throws -> [CLLocationCoordinate2D] {
+        Issue.record("MockH3Service.boundary called unexpectedly")
+        return []
+    }
+
+    func h3Indices(for coordinates: [CLLocationCoordinate2D]) throws -> [String] {
+        Issue.record("MockH3Service.h3Indices called unexpectedly")
+        return []
+    }
+
+    func kRing(for h3Index: String, distance: Int) throws -> [String] {
+        Issue.record("MockH3Service.kRing called unexpectedly")
+        return []
+    }
+
+    func centroid(for h3Index: String) throws -> CLLocationCoordinate2D {
+        // SubmitRunRequestDTO.from() がセルごとに呼ぶ
+        CLLocationCoordinate2D(latitude: 35.6586, longitude: 139.7454)
+    }
+}
+
+enum TestSyncError: Error, LocalizedError {
+    case simulatedNetwork
+    case simulatedAuth
+
+    var errorDescription: String? {
+        switch self {
+        case .simulatedNetwork: "Simulated network error"
+        case .simulatedAuth: "Simulated auth error"
+        }
+    }
+}
+
+@MainActor
+private struct TestHarness {
+    let container: ModelContainer
+    let context: ModelContext
+    let backend: MockRunSyncBackend
+    let service: RunSyncService
+}
+
+@MainActor
+private func makeHarness(
+    backend: MockRunSyncBackend = MockRunSyncBackend()
+) throws -> TestHarness {
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    let container = try ModelContainer(
+        for: RunSession.self, RunLocation.self,
+        configurations: config
+    )
+    let context = container.mainContext
+
+    let service = RunSyncService(
+        modelContext: context,
+        h3Service: MockH3Service(),
+        backend: backend,
+        startsNetworkMonitor: false
+    )
+    return TestHarness(container: container, context: context, backend: backend, service: service)
+}
+
+@Suite(.serialized)
+struct RunSyncServiceTests {
+
+    // MARK: - uploadSession
+
+    @Test @MainActor func uploadSessionWithoutCellsCallsUpsertAndMarksSynced() async throws {
+        let h = try makeHarness()
+        let service = h.service
+        let context = h.context
+        let backend = h.backend
+        _ = h.container
+
+        let session = RunSession(startedAt: Date(), endedAt: Date())
+        context.insert(session)
+        try context.save()
+
+        try await service.uploadSession(session)
+
+        #expect(backend.upsertCalls.count == 1)
+        #expect(session.syncStatus == .synced)
+        #expect(session.lastSyncError == nil)
+        #expect(session.syncRetryCount == 0)
+    }
+
+    @Test @MainActor func uploadSessionWithCellsDataCallsSubmitRun() async throws {
+        let h = try makeHarness()
+        let service = h.service
+        let context = h.context
+        let backend = h.backend
+        _ = h.container
+
+        let cells = [CellCaptureData(h3Index: "abc", distanceMeters: 100)]
+        let cellsData = try JSONEncoder().encode(cells)
+        backend.invokeSubmitRunResponse = SubmitRunResponseDTO(
+            sessionId: UUID().uuidString,
+            cellsCaptured: 3,
+            cellsOverridden: 1,
+            totalCellsProcessed: 4
+        )
+
+        let session = RunSession(startedAt: Date(), endedAt: Date(), cellsData: cellsData)
+        context.insert(session)
+        try context.save()
+
+        try await service.uploadSession(session)
+
+        #expect(backend.invokeSubmitRunCalls.count == 1)
+        #expect(backend.upsertCalls.isEmpty)
+        #expect(session.syncStatus == .synced)
+        #expect(session.cellsCaptured == 3)
+        #expect(session.cellsOverridden == 1)
+    }
+
+    @Test @MainActor func uploadSessionSkipsAlreadySyncedSession() async throws {
+        let h = try makeHarness()
+        let service = h.service
+        let context = h.context
+        let backend = h.backend
+        _ = h.container
+
+        let session = RunSession(startedAt: Date(), endedAt: Date(), syncStatus: .synced)
+        context.insert(session)
+        try context.save()
+
+        try await service.uploadSession(session)
+
+        #expect(backend.upsertCalls.isEmpty)
+        #expect(backend.invokeSubmitRunCalls.isEmpty)
+    }
+
+    @Test @MainActor func uploadSessionProcessesFailedSession() async throws {
+        // `.failed` ステータスのセッションは再度アップロード対象
+        let h = try makeHarness()
+        let service = h.service
+        let context = h.context
+        let backend = h.backend
+        _ = h.container
+
+        let session = RunSession(
+            startedAt: Date(),
+            endedAt: Date(),
+            syncStatus: .failed,
+            lastSyncError: "prior",
+            syncRetryCount: 2
+        )
+        context.insert(session)
+        try context.save()
+
+        try await service.uploadSession(session)
+
+        #expect(backend.upsertCalls.count == 1)
+        #expect(session.syncStatus == .synced)
+        #expect(session.lastSyncError == nil)
+        #expect(session.syncRetryCount == 0)
+    }
+
+    // MARK: - submitCompletedRun
+
+    @Test @MainActor func submitCompletedRunSuccessMarksSynced() async throws {
+        let h = try makeHarness()
+        let service = h.service
+        let context = h.context
+        let backend = h.backend
+        _ = h.container
+        backend.invokeSubmitRunResponse = SubmitRunResponseDTO(
+            sessionId: UUID().uuidString,
+            cellsCaptured: 2,
+            cellsOverridden: 0,
+            totalCellsProcessed: 2
+        )
+
+        let session = RunSession(startedAt: Date(), endedAt: Date())
+        context.insert(session)
+        try context.save()
+
+        await service.submitCompletedRun(session: session, cells: [])
+
+        #expect(session.syncStatus == .synced)
+        #expect(session.cellsCaptured == 2)
+        #expect(session.lastSyncError == nil)
+    }
+
+    @Test @MainActor func submitCompletedRunFailureRecordsFailedState() async throws {
+        let h = try makeHarness()
+        let service = h.service
+        let context = h.context
+        let backend = h.backend
+        _ = h.container
+        backend.invokeSubmitRunError = TestSyncError.simulatedNetwork
+
+        let session = RunSession(startedAt: Date(), endedAt: Date())
+        context.insert(session)
+        try context.save()
+
+        await service.submitCompletedRun(session: session, cells: [])
+
+        #expect(session.syncStatus == .failed)
+        #expect(session.syncRetryCount == 1)
+        #expect(session.lastSyncError == "Simulated network error")
+    }
+
+    // MARK: - syncPendingSessions predicate + retry
+
+    @Test @MainActor func syncPendingSessionsSkipsSessionsAtRetryLimit() async throws {
+        // retryCount >= 5 の .failed セッションは fetch 対象外
+        let h = try makeHarness()
+        let service = h.service
+        let context = h.context
+        let backend = h.backend
+        _ = h.container
+
+        let exhausted = RunSession(
+            startedAt: Date(),
+            endedAt: Date(),
+            syncStatus: .failed,
+            syncRetryCount: 5
+        )
+        let retryable = RunSession(
+            startedAt: Date(),
+            endedAt: Date(),
+            syncStatus: .failed,
+            syncRetryCount: 4
+        )
+        let pending = RunSession(startedAt: Date(), endedAt: Date())
+        context.insert(exhausted)
+        context.insert(retryable)
+        context.insert(pending)
+        try context.save()
+
+        await service.syncPendingSessions()
+
+        // pending + retryable の 2 件だけ upsert される
+        #expect(backend.upsertCalls.count == 2)
+        #expect(exhausted.syncStatus == .failed)
+        #expect(exhausted.syncRetryCount == 5)
+    }
+
+    @Test @MainActor func syncPendingSessionsRecordsFailureAndIncrementsRetry() async throws {
+        let h = try makeHarness()
+        let service = h.service
+        let context = h.context
+        let backend = h.backend
+        _ = h.container
+        backend.upsertError = TestSyncError.simulatedNetwork
+
+        let session = RunSession(startedAt: Date(), endedAt: Date())
+        context.insert(session)
+        try context.save()
+
+        await service.syncPendingSessions()
+
+        #expect(session.syncStatus == .failed)
+        #expect(session.syncRetryCount == 1)
+        #expect(session.lastSyncError == "Simulated network error")
+    }
+
+    @Test @MainActor func syncPendingSessionsNoOpWhenEmpty() async throws {
+        let h = try makeHarness()
+        let service = h.service
+        let backend = h.backend
+        _ = h.container
+
+        await service.syncPendingSessions()
+
+        #expect(backend.upsertCalls.isEmpty)
+        #expect(backend.invokeSubmitRunCalls.isEmpty)
+    }
+}

--- a/run-jinTests/StoreKitServiceTests.swift
+++ b/run-jinTests/StoreKitServiceTests.swift
@@ -1,0 +1,35 @@
+import Testing
+import Foundation
+@testable import run_jin
+
+/// StoreKit の Product / Transaction は StoreKitTest フレームワーク必須のため、
+/// 本ファイルでは StoreKit に触れない pure logic（初期状態、enum の等価性）のみ検証する。
+/// 購入フロー/リストアの統合テストは `.storekit` Configuration を追加した別 PR で対応予定。
+struct StoreKitServiceTests {
+
+    @Test func initialSubscriptionStatusIsUnknown() async throws {
+        let service = StoreKitService()
+        let status = await service.subscriptionStatus
+        #expect(status == .unknown)
+    }
+
+    @Test func subscriptionStatusEnumEquality() {
+        #expect(SubscriptionStatus.unknown == .unknown)
+        #expect(SubscriptionStatus.notSubscribed == .notSubscribed)
+        #expect(SubscriptionStatus.expired == .expired)
+        #expect(SubscriptionStatus.revoked == .revoked)
+
+        let expiry = Date(timeIntervalSince1970: 1_800_000_000)
+        let a = SubscriptionStatus.subscribed(productId: "com.example.monthly", expiresDate: expiry)
+        let b = SubscriptionStatus.subscribed(productId: "com.example.monthly", expiresDate: expiry)
+        let c = SubscriptionStatus.subscribed(productId: "com.example.yearly", expiresDate: expiry)
+        #expect(a == b)
+        #expect(a != c)
+    }
+
+    @Test func subscriptionStatusDistinctCases() {
+        #expect(SubscriptionStatus.unknown != .notSubscribed)
+        #expect(SubscriptionStatus.expired != .revoked)
+        #expect(SubscriptionStatus.notSubscribed != .expired)
+    }
+}


### PR DESCRIPTION
## Summary

issue #108 の一部。**RunSyncService** (前回 PR [#115](https://github.com/imk1t/run-jin/pull/115) の follow-up) と **StoreKitService** (pure logic) のテストを追加。AuthService と StoreKit integration は follow-up PR。

- **Backend 抽象化**: `RunSyncBackendProtocol` (新規) で Supabase への 3 つの RPC (Edge Function / upsert / currentUserId) を抽象化。本番は `SupabaseRunSyncBackend`、テストは `MockRunSyncBackend` を注入。`RunSyncService` は `supabase` global を直接参照しなくなった
- **#Predicate 修正**: `SyncStatus` は `String` rawValue enum で、SwiftData `#Predicate` は直接比較をサポートしないため、`syncRetryCount < retryLimit` のみ SwiftData 側で絞り込み、status は Swift 側フィルタに変更
- **RunSyncServiceTests** (9 ケース): uploadSession (cells なし / cells あり / synced skip / .failed 再処理) ・ submitCompletedRun (成功 / 失敗時 .failed 記録) ・ syncPendingSessions (retry 上限超過 / 失敗時インクリメント / 空の no-op)
- **StoreKitServiceTests** (3 ケース): 初期 .unknown、enum 等価、distinct cases
- **Silent fail 防止**: `MockH3Service` の未使用メソッドは `Issue.record()` で即失敗させる

## Test Plan

- [x] \`make build\` — 警告追加ゼロ ✅
- [x] \`make test\` — 全 44 unique ケース pass、exit 0 ✅ (新規 RunSync 9 + StoreKit 3 含む)
- [x] 既存呼び出し側 (RunningTabView / TabBarView) に変更不要（DI container 経由で backend 注入）
- [x] Production の \`submit-run\` Edge Function 呼び出し / run_sessions upsert / currentUserId の挙動は完全に等価

## Follow-ups (scope out of this PR)

- [ ] **AuthService tests** — 別 PR: Supabase Auth client の DI 抽象化 (`AuthBackendProtocol`) が必要
- [ ] **StoreKit 購入 / restore フロー tests** — 別 PR: \`StoreKitTest\` framework + \`.storekit\` Configuration が必要
- [ ] **`domain-rules` に "sync pipeline は hot path" を明記** — fetch 最適化の判断基準を SKILL.md に追加するかは別途検討
- [ ] \`DependencyContainer\` に \`runSyncBackend\` を expose する（AuthService DI 化時にまとめて）

Closes #108 (partial — 上記 follow-ups 完了後に完全クローズ予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)